### PR TITLE
Modified schema for metadata files, trailing bytes field should be an integer not a string

### DIFF
--- a/sigmf/schema-meta.json
+++ b/sigmf/schema-meta.json
@@ -113,7 +113,7 @@
                 "core:trailing_bytes": {
                     "$id": "#/properties/global/properties/core%3Atrailing_bytes",
                     "description": "The number of bytes to ignore at the end of a Non-Conforming Dataset file.",
-                    "type": "string"
+                    "type": "integer"
                 },
                 "core:version": {
                     "$id": "#/properties/global/properties/core%3Aversion",


### PR DESCRIPTION
Ran into an issue when writing new sigmf-meta files. The schema would throw an error if the `core:trailing_bytes` field was set to an integer, but the field has to be an integer for some math computations, for example those in line 428 in `sigmffile.py`