### PR TITLE
Bugfix: wrong parameter when initializing with data

### DIFF
--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -182,7 +182,7 @@ class SigMFFile(SigMFMetafile):
         if global_info is not None:
             self.set_global_info(global_info)
         if data_file is not None:
-            self.set_data_file(data_file, skip_checksum, map_readonly=map_readonly)
+            self.set_data_file(data_file, skip_checksum=skip_checksum, map_readonly=map_readonly)
 
     def __len__(self):
         return self._memmap.shape[0]


### PR DESCRIPTION
This PR fixes a bug (#10) where the `skip_checksum` argument is incorrectly passed in the position of the `data_buffer` parameter of `set_data_file()` when creating an instance of `SigMFFile` with a pre-existing data file.