### PR TITLE
naive attempt to prevent exception with python 3.6

### DIFF
--- a/sigmf/__init__.py
+++ b/sigmf/__init__.py
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 
 from .archive import SigMFArchive
 from .sigmffile import SigMFFile, SigMFCollection

--- a/sigmf/validate.py
+++ b/sigmf/validate.py
@@ -65,8 +65,7 @@ def validate(metadata, ref_schema=schema.get_schema()):
     -------
     None, will raise error if invalid.
     '''
-    validator = jsonschema.Draft7Validator(schema=ref_schema)
-    validator.validate(instance=metadata)
+    jsonschema.validators.validate(instance=metadata, schema=ref_schema)
 
     # assure capture and annotation order
     # TODO: There is a way to do this with just the schema apparently.


### PR DESCRIPTION
I have no idea how hack-ish this is, but it "doesn't crash" on neither python 3.6 (rockylinux 8.8) nor python 3.10 (ubuntu 22.04)
"fixes" #17 