### PR TITLE
Always set core:version to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ meta = SigMFFile(
         SigMFFile.SAMPLE_RATE_KEY: 48000,
         SigMFFile.AUTHOR_KEY: 'jane.doe@domain.org',
         SigMFFile.DESCRIPTION_KEY: 'All zero complex float32 example file.',
-        SigMFFile.VERSION_KEY: sigmf.__version__,
     }
 )
 
@@ -151,7 +150,6 @@ meta_ci16 = SigMFFile(
         SigMFFile.DATATYPE_KEY: 'ci16_le', # get_data_type_str() is only valid for numpy types
         SigMFFile.SAMPLE_RATE_KEY: 48000,
         SigMFFile.DESCRIPTION_KEY: 'All zero complex int16 file.',
-        SigMFFile.VERSION_KEY: sigmf.__version__,
     }
 )
 meta_ci16.add_capture(0, metadata=meta.get_capture_info(0))
@@ -161,7 +159,6 @@ collection = SigMFCollection(['example_cf32.sigmf-meta', 'example_ci16.sigmf-met
         metadata = {'collection': {
             SigMFCollection.AUTHOR_KEY: 'sigmf@sigmf.org',
             SigMFCollection.DESCRIPTION_KEY: 'Collection of two all zero files.',
-            SigMFCollection.VERSION_KEY: sigmf.__version__,
         }
     }
 )

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -174,7 +174,6 @@ class SigMFFile(SigMFMetafile):
         if metadata is None:
             self._metadata = {self.GLOBAL_KEY:{}, self.CAPTURE_KEY:[], self.ANNOTATION_KEY:[]}
             self._metadata[self.GLOBAL_KEY][self.NUM_CHANNELS_KEY] = 1
-            self._metadata[self.GLOBAL_KEY][self.VERSION_KEY] = __version__
         elif isinstance(metadata, dict):
             self._metadata = metadata
         else:
@@ -183,6 +182,8 @@ class SigMFFile(SigMFMetafile):
             self.set_global_info(global_info)
         if data_file is not None:
             self.set_data_file(data_file, skip_checksum=skip_checksum, map_readonly=map_readonly)
+
+        self._metadata[self.GLOBAL_KEY][self.VERSION_KEY] = '1.0.0'
 
     def __len__(self):
         return self._memmap.shape[0]
@@ -675,7 +676,6 @@ class SigMFCollection(SigMFMetafile):
 
         if metadata is None:
             self._metadata = {self.COLLECTION_KEY:{}}
-            self._metadata[self.COLLECTION_KEY][self.VERSION_KEY] = __version__
             self._metadata[self.COLLECTION_KEY][self.STREAMS_KEY] = []
         else:
             self._metadata = metadata
@@ -687,6 +687,8 @@ class SigMFCollection(SigMFMetafile):
 
         if not self.skip_checksums:
             self.verify_stream_hashes()
+
+        self._metadata[self.COLLECTION_KEY][self.VERSION_KEY] = '1.0.0'
 
     def __len__(self):
         '''

--- a/sigmf/tools/wav2sigmf.py
+++ b/sigmf/tools/wav2sigmf.py
@@ -13,7 +13,6 @@ def writeSigMFArchiveFromWave(input_wav_filename, archive_filename=None, start_d
         SigMFFile.DATATYPE_KEY: get_data_type_str(wav_data),
         SigMFFile.SAMPLE_RATE_KEY: samplerate,
         SigMFFile.DESCRIPTION_KEY: 'Converted from ' + input_wav_filename + '.',
-        SigMFFile.VERSION_KEY: sigmf.__version__,
         SigMFFile.NUM_CHANNELS_KEY: 1 if len(wav_data.shape) < 2 else wav_data.shape[1],
         SigMFFile.RECORDER_KEY: os.path.basename(__file__),
     }

--- a/tests/test_archivereader.py
+++ b/tests/test_archivereader.py
@@ -42,7 +42,6 @@ class TestArchiveReader(unittest.TestCase):
                         global_info={
                             SigMFFile.DATATYPE_KEY: f"{complex_prefix}{key}_le",
                             SigMFFile.NUM_CHANNELS_KEY: num_channels,
-                            SigMFFile.VERSION_KEY: sigmf.__version__,
                         },
                     )
                     temp_meta.tofile(temp_archive, toarchive=True)

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -34,7 +34,7 @@ TEST_METADATA = {
         SigMFFile.DATATYPE_KEY: 'rf32_le',
         SigMFFile.HASH_KEY: 'f4984219b318894fa7144519185d1ae81ea721c6113243a52b51e444512a39d74cf41a4cec3c5d000bd7277cc71232c04d7a946717497e18619bdbe94bfeadd6',
         SigMFFile.NUM_CHANNELS_KEY: 1,
-        SigMFFile.VERSION_KEY: __version__
+        SigMFFile.VERSION_KEY: '1.0.0'
     }
 }
 


### PR DESCRIPTION
Fixes #27.

Currently the `SigMFFile` and `SigMFCollection` constructors allow the caller to pass in `core:version`. The README examples, tools, and tests all set this to `sigmf.__version__`, which is the version number of the Python module, not the SigMF specification.

Since this module implements SigMF v1.0.0, I've modified the constructors to always set `core:version` to `1.0.0`, ignoring any value that may have been provided by the caller.