### PR TITLE
project metadata: specify maximum line length for flake8/pycodestyle

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,3 +15,8 @@ commands =
 deps =
     pytest-cov
 commands = py.test --cov-report term-missing --cov=sigmf tests
+
+[flake8]
+max-line-length = 120
+[pycodestyle]
+max-line-length = 120


### PR DESCRIPTION
After throwing a bit of eyeballing on the existing code base, 120 characters seems to be a common enough and sensible choice of maximum line length


