### PR TITLE
fix data_file in SigMFArchiveReader()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,8 @@ dependencies = [
         "hypothesis",   # next-gen testing framework
     ]
     apps = [
+        "PySimpleGUI",  # for gui interface
         "scipy",        # for wav i/o
-        # FIXME: PySimpleGUI 2024-02-12 v5.0.0 release seems to have a bug. Unpin version when possible.
-        "PySimpleGUI < 5.0.0",  # for gui interface
     ]
 
 [tool.setuptools]
@@ -60,7 +59,7 @@ source = ["sigmf", "tests"]
 command_line = "-m pytest -rA --doctest-modules --junitxml=pytest.xml"
 
 [tool.pytest.ini_options]
-addopts = "--doctest-modules"
+addopts = "--doctest-modules --ignore=sigmf/apps/gui.py"
 
 [tool.pylint]
     [tool.pylint.main]

--- a/sigmf/__init__.py
+++ b/sigmf/__init__.py
@@ -5,18 +5,11 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 # version of this python module
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 # matching version of the SigMF specification
 __specification__ = "1.2.0"
 
+from . import archive, archivereader, error, schema, sigmffile, utils, validate
 from .archive import SigMFArchive
-from .sigmffile import SigMFFile, SigMFCollection
 from .archivereader import SigMFArchiveReader
-
-from . import archive
-from . import archivereader
-from . import error
-from . import schema
-from . import sigmffile
-from . import utils
-from . import validate
+from .sigmffile import SigMFCollection, SigMFFile

--- a/sigmf/apps/gui.py
+++ b/sigmf/apps/gui.py
@@ -10,7 +10,7 @@ import argparse
 import logging
 import os
 
-from PySimpleGUI import *
+import PySimpleGUI as sg
 
 from .. import __version__ as toolversion
 from ..archive import SIGMF_ARCHIVE_EXT
@@ -18,10 +18,10 @@ from ..sigmffile import SigMFFile, dtype_info, fromarchive
 
 log = logging.getLogger()
 
-validate_button = Button('Update', bind_return_key=False, enable_events=True)
-submit_button = Button('Save Archive', disabled=True, button_color=('white', '#D3D3D3'))
-load_button = Button('Load', key='Load Archive')
-combo_button = InputCombo((), size=(20, 1), enable_events=True, key='Capture Combo')
+validate_button = sg.Button('Update', bind_return_key=False, enable_events=True)
+submit_button = sg.Button('Save Archive', disabled=True, button_color=('white', '#D3D3D3'))
+load_button = sg.Button('Load', key='Load Archive')
+combo_button = sg.InputCombo((), size=(20, 1), enable_events=True, key='Capture Combo')
 
 
 class Unit:
@@ -267,7 +267,7 @@ def add_sigmf_field(funct, values, field_name, *args, required=False, type=None,
             else:
                 funct(*args, input)
         except UserWarning as w:
-            Popup('Warning: {}'.format(repr(w)), title='Warning')
+            sg.Popup('Warning: {}'.format(repr(w)), title='Warning')
         except Exception as e:
             show_error(repr(e))
             return False
@@ -278,7 +278,7 @@ def add_sigmf_field(funct, values, field_name, *args, required=False, type=None,
 
 
 def show_error(message):
-    PopupError(message, title='Error', line_width=60)
+    sg.PopupError(message, title='Error', line_width=60)
 
 
 def validate_data(file):
@@ -289,7 +289,7 @@ def validate_data(file):
         submit_button.Update(disabled=True)
         return False
     else:
-        PopupOK('Data is valid\n', file.dumps(pretty=True), title='')
+        sg.PopupOK('Data is valid\n', file.dumps(pretty=True), title='')
         return True
 
 
@@ -305,7 +305,7 @@ def update_capture_screen(capture_data_input, capture_text_blocks, capture_dict)
 def update_global_screen(window_data_input, window_text_blocks, window_dict, archive):
     data_type = window_dict[SigMFFile.DATATYPE_KEY]
     data_info = dtype_info(data_type)
-    sample_size = 64 if '64' in datatype else 32 if '32' in data_type else 16 if '16' in data_type else 8 if '8' in data_type else None
+    sample_size = 64 if '64' in data_type else 32 if '32' in data_type else 16 if '16' in data_type else 8 if '8' in data_type else None
     assert sample_size is not None
     window_text_blocks[WindowInput.DATA_TYPE_FIXEDPOINT].Update(bool(data_info['is_fixedpoint']))
     window_text_blocks[WindowInput.DATA_TYPE_UNSIGNED].Update(bool(data_info['is_unsigned']))
@@ -404,36 +404,36 @@ def main():
     f = SigMFFile()
     capture_selector_dict = {}
 
-    layout = [[Text('This is the SigMF tool to archive RF datasets', size=(80, 1))],
-              [Text('Enter your data and signal captures below. You must include', auto_size_text=True),
-               Text('required', text_color='red', font=DEFAULT_FONT + ('italic',), auto_size_text=True),
-               Text('fields.', size=(50, 1), auto_size_text=True)],
-              [Text('_' * 150, auto_size_text=True)]]
+    layout = [[sg.Text('This is the SigMF tool to archive RF datasets', size=(80, 1))],
+              [sg.Text('Enter your data and signal captures below. You must include', auto_size_text=True),
+               sg.Text('required', text_color='red', font=sg.DEFAULT_FONT + ('italic',), auto_size_text=True),
+               sg.Text('fields.', size=(50, 1), auto_size_text=True)],
+              [sg.Text('_' * 150, auto_size_text=True)]]
 
-    layout.append([Text('Global Data', font=('Arial', 12, 'bold'))])
+    layout.append([sg.Text('Global Data', font=('Arial', 12, 'bold'))])
     num_components = 0
     line = []
     for el in window_input.iter_core():
         size = (30, 1) if len(line) == 0 else (None, None)
         auto_size = True if len(line) == 0 else (10, 1)
-        line.extend([Text(el, justification='right', size=size,
+        line.extend([sg.Text(el, justification='right', size=size,
                           text_color='red' if el in window_input.req_tags else None, auto_size_text=auto_size)])
         if el in window_input.el_multiline:
-            window_text_blocks.update({el: Multiline(window_input.el_text.get(el, ''), key=el,
+            window_text_blocks.update({el: sg.Multiline(window_input.el_text.get(el, ''), key=el,
                                                      tooltip=window_input.el_tooltips.get(el, None), size=(30, 2))})
         elif el in window_input.el_selector:
-            window_text_blocks.update({el: Combo(values=window_input.el_selector[el], key=el,
+            window_text_blocks.update({el: sg.Combo(values=window_input.el_selector[el], key=el,
                                                  size=window_input.el_size.get(el, (None, None)))})
         elif el in window_input.el_checkbox:
-            window_text_blocks.update({el: Checkbox(window_input.el_text.get(el, ''), key=el,
+            window_text_blocks.update({el: sg.Checkbox(window_input.el_text.get(el, ''), key=el,
                                                     size=window_input.el_size.get(el, (None, None)))})
         else:
-            window_text_blocks.update({el: InputText(window_input.el_text.get(el, ''), key=el,
+            window_text_blocks.update({el: sg.InputText(window_input.el_text.get(el, ''), key=el,
                                                      tooltip=window_input.el_tooltips.get(el, None))})
         line.append(window_text_blocks[el])
 
         if el in window_input.el_units:
-            line.append(Text(window_input.el_units[el]))
+            line.append(sg.Text(window_input.el_units[el]))
 
         num_components += 1
         if num_components < window_input.first_line_size:
@@ -447,21 +447,21 @@ def main():
             if el is None:
                 continue
             color = 'red' if el in window_input.req_tags else None
-            window_text_blocks.update({el: InputText(window_input.el_text.get(el, ''), key=el,
+            window_text_blocks.update({el: sg.InputText(window_input.el_text.get(el, ''), key=el,
                                                      tooltip=window_input.el_tooltips.get(el, None))})
-            line.extend([Text(el, justification='right', size=(size, 1), text_color=color), window_text_blocks[el]])
+            line.extend([sg.Text(el, justification='right', size=(size, 1), text_color=color), window_text_blocks[el]])
             if el in window_input.el_units:
-                line.append(Text(window_input.el_units[el], size=(5, 1)))
+                line.append(sg.Text(window_input.el_units[el], size=(5, 1)))
             else:
-                line.append(Text('', size=(5, 1)))
+                line.append(sg.Text('', size=(5, 1)))
         layout.append(line)
 
     layout.extend(
-        [[Text('_' * 150, auto_size_text=True)],
-         [Text('Individual Capture Data', font=('Arial', 12, 'bold'))],
-         [Text('Capture Selector', auto_size_text=True), combo_button, Text('', size=(10, 1)),
-          Button('Add Capture', enable_events=True), Button('Remove Capture', enable_events=True, size=(15, 1)),
-          Button('Clear Capture', enable_events=True, size=(15, 1))]]
+        [[sg.Text('_' * 150, auto_size_text=True)],
+         [sg.Text('Individual Capture Data', font=('Arial', 12, 'bold'))],
+         [sg.Text('Capture Selector', auto_size_text=True), combo_button, sg.Text('', size=(10, 1)),
+          sg.Button('Add Capture', enable_events=True), sg.Button('Remove Capture', enable_events=True, size=(15, 1)),
+          sg.Button('Clear Capture', enable_events=True, size=(15, 1))]]
     )
 
     for el1, el2, el3 in capture_data_input.iter_x(3):
@@ -469,30 +469,30 @@ def main():
         for el in [el1, el2, el3]:
             if el is None:
                 continue
-            capture_text_blocks.update({el: InputText(key=el, tooltip=capture_data_input.el_tooltips.get(el, None))})
+            capture_text_blocks.update({el: sg.InputText(key=el, tooltip=capture_data_input.el_tooltips.get(el, None))})
             color = 'red' if el in capture_data_input.req_tags else None
-            line.extend([Text(el, justification='right', size=(20, 1), text_color=color), capture_text_blocks[el]])
+            line.extend([sg.Text(el, justification='right', size=(20, 1), text_color=color), capture_text_blocks[el]])
             if el in capture_data_input.el_units:
-                line.append(Text(capture_data_input.el_units[el], size=(5, 1)))
+                line.append(sg.Text(capture_data_input.el_units[el], size=(5, 1)))
             else:
-                line.append(Text('', size=(5, 1)))
+                line.append(sg.Text('', size=(5, 1)))
         layout.append(line)
 
     window_text_blocks.update(
-        {WindowInput.DATA_FILE: InputText('', key=WindowInput.DATA_FILE)})
+        {WindowInput.DATA_FILE: sg.InputText('', key=WindowInput.DATA_FILE)})
     layout.extend(
-        [[Text('_' * 150, auto_size_text=True)],
-         [Text('Data Location', font=('Arial', 12, 'bold'))],
-         [Text(WindowInput.DATA_FILE, size=(30, 1), justification='right', text_color='red'),
-          window_text_blocks[WindowInput.DATA_FILE], FileBrowse()],
-         [Text(WindowInput.OUTPUT_FOLDER, size=(30, 1), justification='right'),
-          InputText('', key=WindowInput.OUTPUT_FOLDER), FolderBrowse(), submit_button],
-         [Text(WindowInput.LOAD_PATH, size=(30, 1), justification='right'), InputText('', key=WindowInput.LOAD_PATH),
-          FileBrowse(file_types=(("Archive Files", "*.sigmf"),)), load_button],
-         [validate_button, Button('View Data')]]
+        [[sg.Text('_' * 150, auto_size_text=True)],
+         [sg.Text('Data Location', font=('Arial', 12, 'bold'))],
+         [sg.Text(WindowInput.DATA_FILE, size=(30, 1), justification='right', text_color='red'),
+          window_text_blocks[WindowInput.DATA_FILE], sg.FileBrowse()],
+         [sg.Text(WindowInput.OUTPUT_FOLDER, size=(30, 1), justification='right'),
+          sg.InputText('', key=WindowInput.OUTPUT_FOLDER), sg.FolderBrowse(), submit_button],
+         [sg.Text(WindowInput.LOAD_PATH, size=(30, 1), justification='right'), sg.InputText('', key=WindowInput.LOAD_PATH),
+          sg.FileBrowse(file_types=(("Archive Files", "*.sigmf"),)), load_button],
+         [validate_button, sg.Button('View Data')]]
     )
 
-    window = Window('SigMF Archive Creator',
+    window = sg.Window('SigMF Archive Creator',
                     auto_size_buttons=False,
                     default_element_size=(20, 1),
                     auto_size_text=False,
@@ -534,7 +534,7 @@ def main():
                 add_capture(capture_data_input, capture, capture_selector_dict, f, from_archive=True)
 
         elif event == 'Data Type Help':
-            PopupOK(
+            sg.PopupOK(
                 'Format: <TypeCharacters><ElementBitSize>_<Endianness>\n\n'
                 '\tTypeCharacters:\n'
                 '\t\tUnsigned data: \"u\"\n'
@@ -581,7 +581,7 @@ def main():
                 continue
 
             if validate_data(f):
-                submit_button.Update(disabled=False, button_color=DEFAULT_BUTTON_COLOR)
+                submit_button.Update(disabled=False, button_color=sg.DEFAULT_BUTTON_COLOR)
         elif event == 'Capture Combo':
             capture_dict = capture_selector_dict[values['Capture Combo']]
             update_capture_screen(capture_data_input, capture_text_blocks, capture_dict)
@@ -620,7 +620,7 @@ def main():
         elif event == 'Clear Capture':
             update_capture_screen(capture_data_input, capture_text_blocks, None)
         elif event == 'View Data':
-            PopupOK('Current data:\n', f.dumps(pretty=True), title='')
+            sg.PopupOK('Current data:\n', f.dumps(pretty=True), title='')
         elif event == 'Save Archive':
             output_folder = values[WindowInput.OUTPUT_FOLDER]
             if output_folder == '':
@@ -632,7 +632,7 @@ def main():
             window.Refresh()
             archive_file = output_folder + '/' + os.path.basename(f.data_file).split('.')[0] + SIGMF_ARCHIVE_EXT
             f.archive(archive_file)
-            PopupOK('Saved archive as \n', archive_file, title='')
+            sg.PopupOK('Saved archive as \n', archive_file, title='')
         elif event in ['Cancel', None, 'Exit']:
             window.Close()
             break

--- a/sigmf/archive.py
+++ b/sigmf/archive.py
@@ -6,8 +6,8 @@
 
 """Create and extract SigMF archives."""
 
-import os
 import io
+import os
 import shutil
 import tarfile
 import tempfile
@@ -20,7 +20,7 @@ SIGMF_DATASET_EXT = ".sigmf-data"
 SIGMF_COLLECTION_EXT = ".sigmf-collection"
 
 
-class SigMFArchive():
+class SigMFArchive:
     """Archive a SigMFFile.
 
     A `.sigmf` file must include both valid metadata and data.
@@ -52,6 +52,7 @@ class SigMFArchive():
                          - archive1.sigmf-meta
                          - archive1.sigmf-data
     """
+
     def __init__(self, sigmffile, name=None, fileobj=None):
         self.sigmffile = sigmffile
         self.name = name
@@ -61,9 +62,7 @@ class SigMFArchive():
 
         archive_name = self._get_archive_name()
         sigmf_fileobj = self._get_output_fileobj()
-        sigmf_archive = tarfile.TarFile(mode="w",
-                                        fileobj=sigmf_fileobj,
-                                        format=tarfile.PAX_FORMAT)
+        sigmf_archive = tarfile.TarFile(mode="w", fileobj=sigmf_fileobj, format=tarfile.PAX_FORMAT)
         tmpdir = tempfile.mkdtemp()
         sigmf_md_filename = archive_name + SIGMF_METADATA_EXT
         sigmf_md_path = os.path.join(tmpdir, sigmf_md_filename)
@@ -75,7 +74,7 @@ class SigMFArchive():
 
         if isinstance(self.sigmffile.data_buffer, io.BytesIO):
             self.sigmffile.data_file = sigmf_data_path
-            with open(sigmf_data_path, 'wb') as f:
+            with open(sigmf_data_path, "wb") as f:
                 f.write(self.sigmffile.data_buffer.getbuffer())
         else:
             shutil.copy(self.sigmffile.data_file, sigmf_data_path)

--- a/sigmf/archivereader.py
+++ b/sigmf/archivereader.py
@@ -7,9 +7,11 @@
 """Access SigMF archives without extracting them."""
 
 import os
+import io
 import shutil
 import tarfile
 import tempfile
+from pathlib import Path
 
 from . import __version__
 from .archive import SIGMF_ARCHIVE_EXT, SIGMF_DATASET_EXT, SIGMF_METADATA_EXT, SigMFArchive
@@ -64,6 +66,8 @@ class SigMFArchiveReader():
                 elif memb.name.endswith(SIGMF_DATASET_EXT):
                     data_offset = memb.offset_data
                     data_size_bytes = memb.size
+                    with tar_obj.extractfile(memb) as memb_fid:
+                        data_buffer = io.BytesIO(memb_fid.read())
 
                 else:
                     print('A regular file', memb.name, 'was found but ignored in the archive')
@@ -77,10 +81,8 @@ class SigMFArchiveReader():
         valid_md = self.sigmffile.validate()
 
         self.sigmffile.set_data_file(
-            self.name,
-            data_buffer=archive_buffer,
+            data_buffer=data_buffer,
             skip_checksum=skip_checksum,
-            offset=data_offset,
             size_bytes=data_size_bytes,
             map_readonly=map_readonly,
         )

--- a/sigmf/archivereader.py
+++ b/sigmf/archivereader.py
@@ -6,21 +6,26 @@
 
 """Access SigMF archives without extracting them."""
 
-import os
 import io
+import os
 import shutil
 import tarfile
 import tempfile
 from pathlib import Path
 
 from . import __version__
-from .archive import SIGMF_ARCHIVE_EXT, SIGMF_DATASET_EXT, SIGMF_METADATA_EXT, SigMFArchive
+from .archive import (
+    SIGMF_ARCHIVE_EXT,
+    SIGMF_DATASET_EXT,
+    SIGMF_METADATA_EXT,
+    SigMFArchive,
+)
 from .error import SigMFFileError
 from .sigmffile import SigMFFile
 from .utils import dict_merge
 
 
-class SigMFArchiveReader():
+class SigMFArchiveReader:
     """Access data within SigMF archive `tar` in-place without extracting.
 
     Parameters:
@@ -28,6 +33,7 @@ class SigMFArchiveReader():
       name      -- path to archive file to access. If file does not exist,
                    or if `name` doesn't end in .sigmf, SigMFFileError is raised.
     """
+
     def __init__(self, name=None, skip_checksum=False, map_readonly=True, archive_buffer=None):
         self.name = name
         if self.name is not None:
@@ -38,10 +44,10 @@ class SigMFArchiveReader():
             tar_obj = tarfile.open(self.name)
 
         elif archive_buffer is not None:
-            tar_obj = tarfile.open(fileobj=archive_buffer, mode='r:')
+            tar_obj = tarfile.open(fileobj=archive_buffer, mode="r:")
 
         else:
-            raise ValueError('In sigmf.archivereader.__init__(), either `name` or `archive_buffer` must be not None')
+            raise ValueError("In sigmf.archivereader.__init__(), either `name` or `archive_buffer` must be not None")
 
         json_contents = None
         data_offset = None
@@ -70,12 +76,12 @@ class SigMFArchiveReader():
                         data_buffer = io.BytesIO(memb_fid.read())
 
                 else:
-                    print('A regular file', memb.name, 'was found but ignored in the archive')
+                    print(f"A regular file {memb.name} was found but ignored in the archive")
             else:
-                print('A member of type', memb.type, 'and name', memb.name, 'was found but not handled, just FYI.')
+                print(f"A member of type {memb.type} and name {memb.name} was found but not handled, just FYI.")
 
         if data_offset is None:
-            raise SigMFFileError('No .sigmf-data file found in archive!')
+            raise SigMFFileError("No .sigmf-data file found in archive!")
 
         self.sigmffile = SigMFFile(metadata=json_contents)
         valid_md = self.sigmffile.validate()

--- a/sigmf/sigmf_hash.py
+++ b/sigmf/sigmf_hash.py
@@ -10,23 +10,27 @@ import hashlib
 import os
 
 
-def calculate_sha512(filename=None, fileobj=None, offset_and_size=None):
+def calculate_sha512(filename=None, fileobj=None, offset=None, size=None):
     """
     Return sha512 of file or fileobj.
     """
     the_hash = hashlib.sha512()
+    bytes_to_hash = size
+    bytes_read = 0
+
     if filename is not None:
         fileobj = open(filename, "rb")
-    if offset_and_size is None:
+    if size is None:
         bytes_to_hash = os.path.getsize(filename)
     else:
-        fileobj.seek(offset_and_size[0])
-        bytes_to_hash = offset_and_size[1]
-    bytes_read = 0
+        fileobj.seek(offset)
+
     while bytes_read < bytes_to_hash:
         buff = fileobj.read(min(4096, (bytes_to_hash - bytes_read)))
         the_hash.update(buff)
         bytes_read += len(buff)
+
     if filename is not None:
         fileobj.close()
+
     return the_hash.hexdigest()

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -927,14 +927,14 @@ def get_dataset_filename_from_metadata(meta_fn, metadata=None):
     return None
 
 
-def fromarchive(archive_path, dir=None):
+def fromarchive(archive_path, dir=None, skip_checksum=False):
     """Extract an archive and return a SigMFFile.
 
     The `dir` parameter is no longer used as this function has been changed to
     access SigMF archives without extracting them.
     """
     from .archivereader import SigMFArchiveReader
-    return SigMFArchiveReader(archive_path).sigmffile
+    return SigMFArchiveReader(archive_path, skip_checksum=skip_checksum).sigmffile
 
 
 def fromfile(filename, skip_checksum=False):
@@ -965,7 +965,7 @@ def fromfile(filename, skip_checksum=False):
     file_path, ext = path.splitext(filename) # works with Pathlib - ext contains a dot
 
     if (ext.lower().endswith(SIGMF_ARCHIVE_EXT) or not path.isfile(meta_fn)) and path.isfile(archive_fn):
-        return fromarchive(archive_fn)
+        return fromarchive(archive_fn, skip_checksum=skip_checksum)
 
     if (ext.lower().endswith(SIGMF_COLLECTION_EXT) or not path.isfile(meta_fn)) and path.isfile(collection_fn):
         collection_fp = open(collection_fn, "rb")

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -442,7 +442,7 @@ class SigMFFile(SigMFMetafile):
             sample_count = self._get_sample_count_from_annotations()
         else:
             header_bytes = sum([c.get(self.HEADER_BYTES_KEY, 0) for c in self.get_captures()])
-            file_size = path.getsize(self.data_file) if self.offset_and_size is None else self.offset_and_size[1]
+            file_size = path.getsize(self.data_file) if self.data_size_bytes is None else self.data_size_bytes
             file_data_size = file_size - self.get_global_field(self.TRAILING_BYTES_KEY, 0) - header_bytes  # bytes
             sample_size = self.get_sample_size() # size of a sample in bytes
             num_channels = self.get_num_channels()
@@ -483,9 +483,9 @@ class SigMFFile(SigMFMetafile):
         """
         old_hash = self.get_global_field(self.HASH_KEY)
         if self.data_file is not None:
-            new_hash = sigmf_hash.calculate_sha512(self.data_file, offset_and_size=self.offset_and_size)
+            new_hash = sigmf_hash.calculate_sha512(self.data_file, offset=self.data_offset, size=self.data_size_bytes)
         else:
-            new_hash = sigmf_hash.calculate_sha512(fileobj=self.data_buffer, offset_and_size=self.offset_and_size)
+            new_hash = sigmf_hash.calculate_sha512(fileobj=self.data_buffer, offset=self.data_offset, size=self.data_size_bytes)
         if old_hash:
             if old_hash != new_hash:
                 raise SigMFFileError('Calculated file hash does not match associated metadata.')
@@ -503,7 +503,8 @@ class SigMFFile(SigMFMetafile):
 
         self.data_file = data_file
         self.data_buffer = data_buffer
-        self.offset_and_size = None if (offset == 0 and size_bytes is None) else (offset, size_bytes)
+        self.data_offset = offset
+        self.data_size_bytes = size_bytes
         self._count_samples()
 
         dtype = dtype_info(self.get_global_field(self.DATATYPE_KEY))

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -531,8 +531,8 @@ class SigMFFile(SigMFMetafile):
                 buffer_count = -1 if mapped_length is None else mapped_length
                 raveled = np.frombuffer(self.data_buffer.getbuffer(), count=buffer_count, **common_args)
             else:
-                raise ValueError('In sigmffile.set_data_file(), either data_file or data_buffer must be not None')
-        except:  # TODO include likely exceptions here
+                raise SigMFFileError('In sigmffile.set_data_file(), either data_file or data_buffer must be not None')
+        except SigMFFileError:  # TODO include likely exceptions here
             warnings.warn('Failed to create data array from memory-map-file or buffer!')
         else:
             self._memmap = raveled.reshape(mapped_reshape)

--- a/sigmf/validate.py
+++ b/sigmf/validate.py
@@ -12,12 +12,12 @@ import logging
 import os
 import sys
 
-# required for Python 3.7
-from typing import Optional, Tuple
-
 # multi-threading library - should work well as I/O will be the primary
 # cost for small SigMF files. Swap to ProcessPool if files are large.
 from concurrent.futures import ThreadPoolExecutor, as_completed
+
+# required for Python 3.7
+from typing import Optional, Tuple
 
 import jsonschema
 

--- a/tests/test_archivereader.py
+++ b/tests/test_archivereader.py
@@ -11,6 +11,7 @@ import unittest
 
 import numpy as np
 
+import sigmf
 from sigmf import SigMFArchiveReader, SigMFFile, __specification__
 
 
@@ -80,3 +81,14 @@ class TestArchiveReader(unittest.TestCase):
                         len(readback),
                         "Mismatch in expected readback length",
                     )
+
+
+def test_archiveread_data_file_unchanged(test_sigmffile):
+    with tempfile.NamedTemporaryFile(suffix='.sigmf') as temp:
+        input_samples = test_sigmffile.read_samples()
+        test_sigmffile.archive(temp.name)
+
+        arc = sigmf.sigmffile.fromfile(temp.name)
+        output_samples = arc.read_samples()
+
+        assert np.array_equal(input_samples, output_samples)


### PR DESCRIPTION
When opening a sigmf archive with SigMFArchiveReader(), the data file is
currently set to the full archive (including metadata).

This causes issues when writing the archive back to disk and invalidates
the metadata hash since the data_file is now a tar archive and not just
the set of samples.

To work around the issue, carry around a BytesIO buffer with the content
of the data_file and write it to the tmpdir just before saving a new
archive to disk.
