### PR TITLE
Fix SigMF logo rendering in PyPI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://github.com/gnuradio/SigMF/blob/sigmf-v1.x/logo/sigmf_logo.png" width="30%" /></p>
+<p align="center"><img src="https://github.com/sigmf/SigMF/raw/sigmf-v1.x/logo/sigmf_logo.png" width="30%" /></p>
 
 This python module makes it easy to interact with Signal Metadata Format
 (SigMF) objects. This module works with Python 3.6+ and is distributed freely


### PR DESCRIPTION
This should fix rendering on PyPI and resolve #40 by using the "raw" URL for the logo hosted on GitHub. Using the URLs `https://github.com/sigmf/SigMF/blob/sigmf-v1.x/logo/sigmf_logo.png?raw=true` or `https://raw.githubusercontent.com/sigmf/SigMF/sigmf-v1.x/logo/sigmf_logo.png` should be equivalent and also work.

A maintainer can test this change by cloning this branch, building the project, and [uploading to TestPyPI](https://packaging.python.org/en/latest/guides/using-testpypi/).