### PR TITLE
Fix annotation core:sample_count requirement

### DIFF
--- a/sigmf/schema-meta.json
+++ b/sigmf/schema-meta.json
@@ -238,8 +238,7 @@
                         "$id": "#/properties/annotations/items/anyOf/0",
                         "description": "The annotations value is an array of annotation segment objects that describe anything regarding the signal data not part of the Captures and Global objects. It MUST be sorted by the value of each Annotation Segment's `core:sample_start` key, ascending.",
                         "required": [
-                            "core:sample_start",
-                            "core:sample_count"
+                            "core:sample_start"
                         ],
                         "type": "object",
                         "properties": {

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -368,15 +368,17 @@ class SigMFFile(SigMFMetafile):
             end_byte += (self.get_capture_start(index+1) - self.get_capture_start(index)) * self.get_sample_size() * self.get_num_channels()
         return (start_byte, end_byte)
 
-    def add_annotation(self, start_index, length, metadata=None):
+    def add_annotation(self, start_index, length=None, metadata=None):
         """
-        Insert annotation at start_index with length.
+        Insert annotation at start_index with length (if != None).
         """
         assert start_index >= self._get_start_offset()
-        assert length >= 1
+
         new_annot = metadata or {}
         new_annot[self.START_INDEX_KEY] = start_index
-        new_annot[self.LENGTH_INDEX_KEY] = length
+        if length is not None:
+            assert length >= 1
+            new_annot[self.LENGTH_INDEX_KEY] = length
 
         self._metadata[self.ANNOTATION_KEY] += [new_annot]
         # sort annotations by start_index

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -81,6 +81,16 @@ class FailingCases(unittest.TestCase):
         with self.assertRaises(ValidationError):
             SigMFFile(self.metadata).validate()
 
+    def test_annotation_without_sample_count(self):
+        '''annotation without length should be accepted'''
+        self.metadata[SigMFFile.ANNOTATION_KEY] = [
+            {
+                SigMFFile.START_INDEX_KEY: 2
+            }
+        ]
+        SigMFFile(self.metadata).validate()
+
+
     def test_invalid_hash(self):
         _, temp_path = tempfile.mkstemp()
         TEST_FLOAT32_DATA.tofile(temp_path)


### PR DESCRIPTION
According to spec, core:sample_count for annotation is optional:

_The sample_count Field
The number of samples that this Segment applies to. If sample_count is not provided, it SHOULD be assumed that the annotation applies from sample_start through the end of the Dataset, in all other cases sample_count MUST be provided._