### PR TITLE
Fix count samples from annotations

### DIFF
--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -402,11 +402,23 @@ class SigMFFile(SigMFMetafile):
         list of dict
             Each dictionary contains one annotation for the sample at `index`.
         '''
-        return [
-            x for x in self._metadata.get(self.ANNOTATION_KEY, [])
-            if index is None or (x[self.START_INDEX_KEY] <= index
-            and (self.LENGTH_INDEX_KEY not in x or x[self.START_INDEX_KEY] + x[self.LENGTH_INDEX_KEY] > index))
-        ]
+        annotations = self._metadata.get(self.ANNOTATION_KEY, [])
+        if index is None:
+            return annotations
+        
+        annotations_including_index = []
+        for annotation in annotations:
+            if index < annotation[self.START_INDEX_KEY]:
+                # index is before annotation starts -> skip
+                continue
+            if self.LENGTH_INDEX_KEY in annotation:
+                # Annotation includes sample_count -> check end index
+                if index >= annotation[self.START_INDEX_KEY] + annotation[self.LENGTH_INDEX_KEY]:
+                    # index is after annotation end -> skip
+                    continue
+            
+            annotations_including_index.append(annotation)
+        return annotations_including_index
 
     def get_sample_size(self):
         """

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -405,7 +405,7 @@ class SigMFFile(SigMFMetafile):
         return [
             x for x in self._metadata.get(self.ANNOTATION_KEY, [])
             if index is None or (x[self.START_INDEX_KEY] <= index
-            and x[self.START_INDEX_KEY] + x[self.LENGTH_INDEX_KEY] > index)
+            and (self.LENGTH_INDEX_KEY not in x or x[self.START_INDEX_KEY] + x[self.LENGTH_INDEX_KEY] > index))
         ]
 
     def get_sample_size(self):
@@ -418,16 +418,13 @@ class SigMFFile(SigMFMetafile):
     def _count_samples(self):
         """
         Count, set, and return the total number of samples in the data file.
-        If there is no data file but there are annotations, use the end index
-        of the final annotation instead. If there are no annotations, use 0.
+        If there is no data file but there are annotations, use the sample_count
+        from the annotation with the highest end index. If there are no annotations,
+        use 0.
         For complex data, a 'sample' includes both the real and imaginary part.
         """
-        annotations = self.get_annotations()
         if self.data_file is None:
-            if len(annotations) > 0:
-                sample_count = annotations[-1][self.START_INDEX_KEY] + annotations[-1][self.LENGTH_INDEX_KEY]
-            else:
-                sample_count = 0
+            sample_count = self._get_sample_count_from_annotations()
         else:
             header_bytes = sum([c.get(self.HEADER_BYTES_KEY, 0) for c in self.get_captures()])
             file_size = path.getsize(self.data_file) if self.offset_and_size is None else self.offset_and_size[1]
@@ -438,11 +435,31 @@ class SigMFFile(SigMFMetafile):
             if file_data_size % (sample_size * num_channels) != 0:
                 warnings.warn(f'File `{self.data_file}` does not contain an integer '
                     'number of samples across channels. It may be invalid data.')
-            if len(annotations) > 0 and annotations[-1][self.START_INDEX_KEY] + annotations[-1][self.LENGTH_INDEX_KEY] > sample_count:
+            if self._get_sample_count_from_annotations() > sample_count:
                 warnings.warn(f'File `{self.data_file}` ends before the final annotation '
                     'in the corresponding SigMF metadata.')
         self.sample_count = sample_count
         return sample_count
+
+    def _get_sample_count_from_annotations(self):
+        """
+        Returns the number of samples based on annotation with highest end index.
+        NOTE: Annotations are ordered by START_INDEX_KEY and not end index, so we
+        need to go through all annotations
+        """
+        annon_sample_count = []
+        for annon in self.get_annotations():
+            if self.LENGTH_INDEX_KEY in annon:
+                # Annotation with sample_count
+                annon_sample_count.append(annon[self.START_INDEX_KEY] + annon[self.LENGTH_INDEX_KEY])
+            else:
+                # Annotation without sample_count - sample count must be at least sample_start
+                annon_sample_count.append(annon[self.START_INDEX_KEY])
+
+        if annon_sample_count:
+            return max(annon_sample_count)
+        else:
+            return 0
 
     def calculate_hash(self):
         """

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -38,6 +38,20 @@ TEST_METADATA = {
     }
 }
 
+TEST_METADATA_MULTI_ANNON = {
+    SigMFFile.ANNOTATION_KEY: [
+        {SigMFFile.START_INDEX_KEY: 0},
+        {SigMFFile.LENGTH_INDEX_KEY: 32, SigMFFile.START_INDEX_KEY: 0},
+        {SigMFFile.LENGTH_INDEX_KEY: 4, SigMFFile.START_INDEX_KEY: 4}],
+    SigMFFile.CAPTURE_KEY: [{SigMFFile.START_INDEX_KEY: 0}],
+    SigMFFile.GLOBAL_KEY: {
+        SigMFFile.DATATYPE_KEY: 'rf32_le',
+        SigMFFile.HASH_KEY: 'f4984219b318894fa7144519185d1ae81ea721c6113243a52b51e444512a39d74cf41a4cec3c5d000bd7277cc71232c04d7a946717497e18619bdbe94bfeadd6',
+        SigMFFile.NUM_CHANNELS_KEY: 1,
+        SigMFFile.VERSION_KEY: '1.0.0'
+    }
+}
+
 # Data0 is a test of a compliant two capture recording
 TEST_U8_DATA0 = list(range(256))
 TEST_U8_META0 = {

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -38,20 +38,6 @@ TEST_METADATA = {
     }
 }
 
-TEST_METADATA_MULTI_ANNON = {
-    SigMFFile.ANNOTATION_KEY: [
-        {SigMFFile.START_INDEX_KEY: 0},
-        {SigMFFile.LENGTH_INDEX_KEY: 32, SigMFFile.START_INDEX_KEY: 0},
-        {SigMFFile.LENGTH_INDEX_KEY: 4, SigMFFile.START_INDEX_KEY: 4}],
-    SigMFFile.CAPTURE_KEY: [{SigMFFile.START_INDEX_KEY: 0}],
-    SigMFFile.GLOBAL_KEY: {
-        SigMFFile.DATATYPE_KEY: 'rf32_le',
-        SigMFFile.HASH_KEY: 'f4984219b318894fa7144519185d1ae81ea721c6113243a52b51e444512a39d74cf41a4cec3c5d000bd7277cc71232c04d7a946717497e18619bdbe94bfeadd6',
-        SigMFFile.NUM_CHANNELS_KEY: 1,
-        SigMFFile.VERSION_KEY: '1.0.0'
-    }
-}
-
 # Data0 is a test of a compliant two capture recording
 TEST_U8_DATA0 = list(range(256))
 TEST_U8_META0 = {


### PR DESCRIPTION
Fixed two scenarios where SigMFFile._count_samples() failed:

1. No data_file registered: sample_count should be calculated from annotation with highest end index, not from annotation with highest start index
2. If no core:sample_count is provided in the annotation, core:sample_start should be used (sample count must at least be equal to this)