### PR TITLE
override global info instead of replace on __init__

### DIFF
--- a/sigmf/__init__.py
+++ b/sigmf/__init__.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 # version of this python module
-__version__ = "1.2.4"
+__version__ = "1.2.5"
 # matching version of the SigMF specification
 __specification__ = "1.2.0"
 

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -287,9 +287,9 @@ class SigMFFile(SigMFMetafile):
 
     def set_global_info(self, new_global):
         """
-        Overwrite the global info with a new dictionary.
+        Recursively override existing global metadata with new global metadata.
         """
-        self._metadata[self.GLOBAL_KEY] = new_global.copy()
+        self._metadata[self.GLOBAL_KEY] = dict_merge(self._metadata[self.GLOBAL_KEY], new_global)
 
     def get_global_info(self):
         """


### PR DESCRIPTION
Override not overwrite global information when creating new `SigMFFile`.

Closes #76.

Should this be the behavior for `set_collection_info` too?
```python
# currently
def set_collection_info(self, new_collection):
    """
    Overwrite the collection info with a new dictionary.
    """
    self._metadata[self.COLLECTION_KEY] = new_collection.copy()
```