### PR TITLE
Fix file path handling for non-conforming datasets

### DIFF
--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -932,12 +932,15 @@ def get_dataset_filename_from_metadata(meta_fn, metadata=None):
     Parse provided metadata and return the expected data filename. In the case of
     a metadata only distribution, or if the file does not exist, this will return
     'None'. The priority for conflicting:
-      1. The file named <METAFILE_BASENAME>.sigmf-meta if it exists
+      1. The file named <METAFILE_BASENAME>.sigmf-data if it exists
       2. The file in the `core:dataset` field (Non-Compliant Dataset) if it exists
       3. None (may be a metadata only distribution)
     """
     compliant_data_fn = get_sigmf_filenames(meta_fn)["data_fn"]
     noncompliant_data_fn = metadata["global"].get("core:dataset", None)
+    dir_path = path.split(meta_fn)[0]
+    if not dir_path:
+        dir_path = "."  # sets the correct path in the case meta_fn is only a filename
 
     if path.isfile(compliant_data_fn):
         if noncompliant_data_fn:
@@ -948,13 +951,14 @@ def get_dataset_filename_from_metadata(meta_fn, metadata=None):
         return compliant_data_fn
 
     elif noncompliant_data_fn:
-        if path.isfile(noncompliant_data_fn):
+        noncompliant_data_file_path = f"{dir_path}/{noncompliant_data_fn}"
+        if path.isfile(noncompliant_data_file_path):
             if metadata["global"].get("core:metadata_only", False):
                 warnings.warn(
-                    'Schema defines "core:dataset" but "core:meatadata_only" '
+                    'Schema defines "core:dataset" but "core:metadata_only" '
                     f"also exists; using `{noncompliant_data_fn}`"
                 )
-            return noncompliant_data_fn
+            return noncompliant_data_file_path
         else:
             warnings.warn(
                 f"Non-Compliant Dataset `{noncompliant_data_fn}` is specified " 'in "core:dataset" but does not exist!'

--- a/tests/test_load_ncd.py
+++ b/tests/test_load_ncd.py
@@ -1,0 +1,62 @@
+# Copyright: Multiple Authors
+#
+# This file is part of sigmf-python. https://github.com/sigmf/sigmf-python
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+"""Tests for loading non-conforming datasets"""
+
+import os
+import numpy as np
+import pytest
+from sigmf.sigmffile import SigMFFile, fromfile
+
+
+@pytest.mark.parametrize(
+    ["file_path"],
+    [
+        ["b1.bin"],
+        ["./b2.bin"],
+        ["test_subdir/b3.bin"],  # fails in the 1.2.3 version
+        ["./test_subdir/b4.bin"],  # fails in the 1.2.3 version
+    ],
+)
+def test_load_ncd(file_path: str) -> None:
+    dir_path, file_name = os.path.split(file_path)
+    file_name_base, file_name_ext = os.path.splitext(file_name)
+    if not dir_path:
+        dir_path = "."  # sets the correct path in the case file is only a filename
+    meta_file_path = f"{dir_path}/{file_name_base}.sigmf-meta"
+
+    # create dir
+    try:
+        os.makedirs(dir_path)
+    except FileExistsError:
+        pass
+
+    # create dataset
+    np.arange(10, dtype=np.int16).tofile(file_path)
+
+    # create metadata file
+    metadata = {
+        SigMFFile.GLOBAL_KEY: {
+            SigMFFile.DATATYPE_KEY: "ri16_le",
+            SigMFFile.DATASET_KEY: file_name,
+        },
+        SigMFFile.CAPTURE_KEY: [
+            {
+            SigMFFile.START_INDEX_KEY: 0,
+            }
+        ],
+        SigMFFile.ANNOTATION_KEY: [],
+    }
+    meta_file = SigMFFile(metadata=metadata, data_file=file_path)
+    meta_file.tofile(meta_file_path)
+
+    # load dataset
+    data = fromfile(meta_file_path)
+
+    assert np.array_equal(
+        np.arange(10, dtype=np.int16),
+        data.read_samples(autoscale=False),
+    )


### PR DESCRIPTION
Fixes #78.

The ```get_dataset_filename_from_metadata``` function returns the full file path for non-conforming datasets, not just the file name. Furthermore an unit test verifying this, plus a couple of typos described in the above issue fixed. 
