### PR TITLE
increment patch for pypi

### DIFF
--- a/sigmf/__init__.py
+++ b/sigmf/__init__.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 # version of this python module
-__version__ = "1.2.5"
+__version__ = "1.2.6"
 # matching version of the SigMF specification
 __specification__ = "1.2.3"
 


### PR DESCRIPTION
PyPi does not allow re-uploading fixed versions, so I unfortunately need to increment the patch with no changes due to a mistake during packaging `v1.2.5`.