### PR TITLE
Take filenames with dots into account in get_sigmf_filenames()

### DIFF
--- a/sigmf/__init__.py
+++ b/sigmf/__init__.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 # version of this python module
-__version__ = "1.2.8"
+__version__ = "1.2.9"
 # matching version of the SigMF specification
 __specification__ = "1.2.3"
 

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -1111,11 +1111,26 @@ def get_sigmf_filenames(filename):
     -------
     dict with 'data_fn', 'meta_fn', and 'archive_fn' as keys.
     """
-    stem_path = Path(filename).with_suffix("")
+    stem_path = Path(filename)
+    # If the path has a sigmf suffix, remove it. Otherwise do not remove the
+    # suffix, because the filename might contain '.' characters which are part
+    # of the filename rather than an extension.
+    sigmf_suffixes = [
+        SIGMF_DATASET_EXT, SIGMF_METADATA_EXT,
+        SIGMF_ARCHIVE_EXT, SIGMF_COLLECTION_EXT,
+    ]
+    if stem_path.suffix in sigmf_suffixes:
+        with_suffix_path = stem_path
+        stem_path = stem_path.with_suffix("")
+    else:
+        # Add a dummy suffix to prevent the .with_suffix() calls below from
+        # overriding part of the filename which is interpreted as a suffix
+        with_suffix_path = stem_path.with_name(f"{stem_path.name}{SIGMF_DATASET_EXT}")
+
     return {
         "base_fn": stem_path,
-        "data_fn": stem_path.with_suffix(SIGMF_DATASET_EXT),
-        "meta_fn": stem_path.with_suffix(SIGMF_METADATA_EXT),
-        "archive_fn": stem_path.with_suffix(SIGMF_ARCHIVE_EXT),
-        "collection_fn": stem_path.with_suffix(SIGMF_COLLECTION_EXT),
+        "data_fn": with_suffix_path.with_suffix(SIGMF_DATASET_EXT),
+        "meta_fn": with_suffix_path.with_suffix(SIGMF_METADATA_EXT),
+        "archive_fn": with_suffix_path.with_suffix(SIGMF_ARCHIVE_EXT),
+        "collection_fn": with_suffix_path.with_suffix(SIGMF_COLLECTION_EXT),
     }

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -915,13 +915,13 @@ class SigMFCollection(SigMFMetafile):
         """
         Returns the SigMFFile instance of the specified stream if it exists
         """
-        metafile = None
-        if stream_name is not None:
-            if stream_name in self.get_stream_names():
-                metafile = stream_name + ".sigmf_meta"
+        if stream_name is not None and stream_name not in self.get_stream_names():
+            # invalid stream name
+            return
         if stream_index is not None and stream_index < len(self):
-            metafile = self.get_stream_names()[stream_index] + ".sigmf_meta"
-        if metafile is not None:
+            stream_name = self.get_stream_names()[stream_index]
+        if stream_name is not None:
+            metafile = get_sigmf_filenames(stream_name)["meta_fn"]
             metafile_path = self.base_path / metafile
             return fromfile(metafile_path, skip_checksum=self.skip_checksums)
 

--- a/tests/test_sigmffile.py
+++ b/tests/test_sigmffile.py
@@ -43,6 +43,21 @@ class TestClassMethods(unittest.TestCase):
         obj_pth = sigmffile.fromfile(self.temp_path_data)
         obj_pth.validate()
 
+    def test_filenames_with_dots(self):
+        """test that filenames with . characters are handled correctly"""
+        filenames = ["a", "b.c", "d.e.f"]
+        for filename in filenames:
+            temp_path_data = self.temp_dir / f"{filename}.sigmf-data"
+            temp_path_meta = self.temp_dir / f"{filename}.sigmf-meta"
+            TEST_FLOAT32_DATA.tofile(temp_path_data)
+            self.sigmf_object = SigMFFile(TEST_METADATA, data_file=temp_path_data)
+            self.sigmf_object.tofile(temp_path_meta)
+            files = [str(temp_path_data), temp_path_data,
+                     str(temp_path_meta), temp_path_meta]
+            for f in files:
+                obj = sigmffile.fromfile(f)
+                obj.validate()
+
     def test_iterator_basic(self):
         """make sure default batch_size works"""
         count = 0

--- a/tests/test_sigmffile.py
+++ b/tests/test_sigmffile.py
@@ -44,7 +44,7 @@ class TestClassMethods(unittest.TestCase):
         obj_pth.validate()
 
     def test_filenames_with_dots(self):
-        """test that filenames with . characters are handled correctly"""
+        """test that filenames with non-extension . characters are handled correctly"""
         filenames = ["a", "b.c", "d.e.f"]
         for filename in filenames:
             temp_path_data = self.temp_dir / f"{filename}.sigmf-data"
@@ -52,10 +52,9 @@ class TestClassMethods(unittest.TestCase):
             TEST_FLOAT32_DATA.tofile(temp_path_data)
             self.sigmf_object = SigMFFile(TEST_METADATA, data_file=temp_path_data)
             self.sigmf_object.tofile(temp_path_meta)
-            files = [str(temp_path_data), temp_path_data,
-                     str(temp_path_meta), temp_path_meta]
-            for f in files:
-                obj = sigmffile.fromfile(f)
+            files = [str(temp_path_data), temp_path_data, str(temp_path_meta), temp_path_meta]
+            for filename in files:
+                obj = sigmffile.fromfile(filename)
                 obj.validate()
 
     def test_iterator_basic(self):


### PR DESCRIPTION
The function get_sigmf_filenames() does not work correctly if a file contains dots in the filename. These are interpretted as suffixes by pathlib, and a part of the filename can be removed when forming the different SigMF filenames. This fixes the problem by only considering as file extensions the canonical SigMF file extensions. Any other suffixes are treated as part of the filename and not removed.

This fixes #106.