### PR TITLE
Add scipy as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dynamic = ["version", "readme"]
 requires-python = ">=3.7"
 dependencies = [
     "numpy",        # for vector math
+    "scipy",        # used in sigmf.apps.convert_wav
     "jsonschema",   # for spec validation
 ]
     [project.urls]


### PR DESCRIPTION
scipy is imported in sigmf.apps.convert_wav, so it needs to be listed as a dependency in pyproject.toml.