### PR TITLE
Feature: Unify sample access

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -115,3 +115,24 @@ method-based approach.
    Only core **global** fields support attribute access. Capture and annotation
    fields must still be accessed using the traditional ``get_captures()`` and
    ``get_annotations()`` methods.
+
+--------------------------------
+Control Fixed-Point Data Scaling
+--------------------------------
+
+For fixed-point datasets, you can control whether samples are automatically scaled to floating-point values:
+
+.. code-block:: python
+
+    import sigmf
+
+    # Default behavior: autoscale fixed-point data to [-1.0, 1.0] range
+    handle = sigmf.fromfile("fixed_point_data.sigmf")
+    samples = handle.read_samples()  # Returns float32/complex64
+
+    # Disable autoscaling to access raw integer values
+    handle_raw = sigmf.fromfile("fixed_point_data.sigmf", autoscale=False)
+    raw_samples = handle_raw.read_samples()  # Returns original integer types
+
+    # Both slicing and read_samples() respect the autoscale setting
+    assert handle[0:10].dtype == handle.read_samples(count=10).dtype

--- a/sigmf/__init__.py
+++ b/sigmf/__init__.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 # version of this python module
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 # matching version of the SigMF specification
 __specification__ = "1.2.6"
 

--- a/sigmf/archivereader.py
+++ b/sigmf/archivereader.py
@@ -29,7 +29,9 @@ class SigMFArchiveReader:
     map_readonly : bool, optional
         Indicate whether assignments on the numpy.memmap are allowed.
     archive_buffer : buffer, optional
-
+        Alternative buffer to read archive from.
+    autoscale : bool, optional
+        If dataset is in a fixed-point representation, scale samples from (min, max) to (-1.0, 1.0).
 
     Raises
     ------
@@ -41,7 +43,7 @@ class SigMFArchiveReader:
         If metadata is invalid.
     """
 
-    def __init__(self, name=None, skip_checksum=False, map_readonly=True, archive_buffer=None):
+    def __init__(self, name=None, skip_checksum=False, map_readonly=True, archive_buffer=None, autoscale=True):
         if name is not None:
             path = Path(name)
             if path.suffix != SIGMF_ARCHIVE_EXT:
@@ -90,7 +92,7 @@ class SigMFArchiveReader:
         if data_offset is None:
             raise SigMFFileError("No .sigmf-data file found in archive!")
 
-        self.sigmffile = SigMFFile(metadata=json_contents)
+        self.sigmffile = SigMFFile(metadata=json_contents, autoscale=autoscale)
         self.sigmffile.validate()
 
         self.sigmffile.set_data_file(

--- a/tests/test_archivereader.py
+++ b/tests/test_archivereader.py
@@ -60,7 +60,7 @@ class TestArchiveReader(unittest.TestCase):
                     if complex_prefix == "c":
                         # complex data will be half as long
                         target_count //= 2
-                        self.assertTrue(np.all(np.iscomplex(readback_samples)))
+                        self.assertTrue(np.iscomplexobj(readback_samples))
                     if num_channels != 1:
                         # check expected # of channels
                         self.assertEqual(


### PR DESCRIPTION
Overdue fix that makes memory slices match read_samples behavior in all cases.

Currently blocked by PR #116.

Closes issue #60.

Introduces a breaking API change to rarely used kwargs (`autoscale` and `raw_components`) from `SigMFFile.read_samples()`. As such I also increment minor version.