### PR TITLE
fix capture byte boundaries for archives

### DIFF
--- a/sigmf/__init__.py
+++ b/sigmf/__init__.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 # version of this python module
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 # matching version of the SigMF specification
 __specification__ = "1.2.6"
 


### PR DESCRIPTION
Ensures identical behavior for `get_capture_byte_boundaries` for archives & pairs.

Increment minor version for API change. I did leave the old misnamed method for now with a deprecation warning.

Closes #70.