### PR TITLE
support for BLUE uint16 & uint32, with testing

### DIFF
--- a/docs/source/converters.rst
+++ b/docs/source/converters.rst
@@ -137,9 +137,9 @@ The following table summarizes tested BLUE formats and their compatibility with 
     :header-rows: 1
     :stub-columns: 1
 
-    "Code", ":abbr:`B (int8)`", ":abbr:`I (int16)`", ":abbr:`L (int32)`", ":abbr:`X (int64)`", ":abbr:`F (float32)`", ":abbr:`D (float64)`", ":abbr:`P (packed)`", ":abbr:`N (int4)`"
-    ":abbr:`S (scalar)`", "✅", "✅", "✅", "✅", "✅", "✅", "❌", "❌"
-    ":abbr:`C (complex)`", "✅", "✅", "✅", "✅", "✅", "✅", "❌", "❌"
+    "Code", ":abbr:`P (packed)`", ":abbr:`N (int4)`", ":abbr:`B (int8)`", ":abbr:`U (uint16)`", ":abbr:`I (int16)`", ":abbr:`V (uint32)`", ":abbr:`L (int32)`", ":abbr:`F (float32)`", ":abbr:`X (int64)`", ":abbr:`D (float64)`", ":abbr:`O (excess-128)`"
+    ":abbr:`S (scalar)`", "❌", "❌", "✅", "✅", "✅", "✅", "✅", "✅", "✅", "✅", "❌"
+    ":abbr:`C (complex)`", "❌", "❌", "✅", "✅", "✅", "✅", "✅", "✅", "✅", "✅", "❌"
 
 **Legend:**
     * ✅ = Tested and known working

--- a/sigmf/__init__.py
+++ b/sigmf/__init__.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 # version of this python module
-__version__ = "1.6.1"
+__version__ = "1.6.2"
 # matching version of the SigMF specification
 __specification__ = "1.2.6"
 

--- a/sigmf/convert/blue.py
+++ b/sigmf/convert/blue.py
@@ -67,17 +67,19 @@ BLOCK_SIZE_BYTES = 512
 
 TYPE_MAP = {
     # BLUE format code to numpy dtype
-    # note new non 1-1 mapping supported needs new handling in data_loopback
+    # note: new non 1-1 mapping supported needs new handling in data_loopback
+    # "P" : packed bits,
     "A": np.dtype("S1"),  # ASCII for unpacking text fields
+    # "N" : 4-bit integer,
     "B": np.int8,
+    "U": np.uint16,
     "I": np.int16,
+    "V": np.uint32,
     "L": np.int32,
-    "X": np.int64,
     "F": np.float32,
+    "X": np.int64,
     "D": np.float64,
-    # unsupported codes
-    # "P" : packed bits
-    # "N" : 4-bit integer
+    # "O": excess-128,
 }
 
 
@@ -108,7 +110,12 @@ def blue_to_sigmf_type_str(h_fixed: dict) -> str:
     bits = dtype_obj.itemsize * 8  # bytes to bits
 
     # infer sigmf type from numpy kind
-    sigmf_type = "i" if dtype_obj.kind in ("i", "u") else "f"
+    if dtype_obj.kind == "u":
+        sigmf_type = "u"
+    elif dtype_obj.kind == "i":
+        sigmf_type = "i"
+    else:
+        sigmf_type = "f"
 
     # build datatype string
     prefix = "c" if is_complex else "r"


### PR DESCRIPTION
Added support for converting BLUE files containing `uint32` and `uint64` data with associated tests.

Increment to `v1.6.2`.