### PR TITLE
Reorder priority for conflicting datasets

### DIFF
--- a/sigmf/__init__.py
+++ b/sigmf/__init__.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 # version of this python module
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 # matching version of the SigMF specification
 __specification__ = "1.2.6"
 

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -1217,22 +1217,19 @@ def get_dataset_filename_from_metadata(meta_fn, metadata=None):
 
     Priority for conflicting datasets:
 
-    1. Use the file named ``<stem>.SIGMF_DATASET_EXT`` if it exists.
-    2. Use the file in the ``DATASET_KEY`` field (non-compliant dataset) if it exists.
+    1. Use the file in the ``DATASET_KEY`` field (non-compliant dataset) if it exists.
+    2. Use the file named ``<stem>.SIGMF_DATASET_EXT`` if it exists.
     3. Return ``None`` (may be a metadata-only distribution).
     """
     compliant_filename = get_sigmf_filenames(meta_fn)["data_fn"]
     noncompliant_filename = metadata["global"].get(SigMFFile.DATASET_KEY, None)
 
-    if Path.is_file(compliant_filename):
-        if noncompliant_filename:
+    if noncompliant_filename:
+        if Path.is_file(compliant_filename):
             warnings.warn(
-                f"Compliant Dataset `{compliant_filename}` exists but "
-                f"{SigMFFile.DATASET_KEY} is also defined; using `{compliant_filename}`"
+                f"{SigMFFile.DATASET_KEY} is defined but compliant dataset `{compliant_filename}` exists; "
+                f"using `{noncompliant_filename}` specified by {SigMFFile.DATASET_KEY}"
             )
-        return compliant_filename
-
-    elif noncompliant_filename:
         dir_path = Path(meta_fn).parent
         noncompliant_data_file_path = Path.joinpath(dir_path, noncompliant_filename)
         if Path.is_file(noncompliant_data_file_path):
@@ -1247,6 +1244,8 @@ def get_dataset_filename_from_metadata(meta_fn, metadata=None):
                 f"Non-Compliant Dataset `{noncompliant_filename}` is specified in {SigMFFile.DATASET_KEY} "
                 "but does not exist!"
             )
+    elif Path.is_file(compliant_filename):
+        return compliant_filename
     return None
 
 

--- a/tests/test_ncd.py
+++ b/tests/test_ncd.py
@@ -10,6 +10,7 @@ import copy
 import shutil
 import tempfile
 import unittest
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -61,3 +62,38 @@ class TestNonConformingDataset(unittest.TestCase):
         Path.unlink(data_path)
         with self.assertRaises(SigMFFileError):
             _ = fromfile(meta_path)
+
+    def test_ncd_priority_over_conforming_dataset(self) -> None:
+        """test that NCD file specified in core:dataset is prioritized over .sigmf-data file"""
+        base_name = "conflicting_dataset"
+        meta_path = self.temp_dir / f"{base_name}.sigmf-meta"
+        ncd_path = self.temp_dir / f"{base_name}.fleeb"
+        conforming_path = self.temp_dir / f"{base_name}.sigmf-data"
+
+        # create two different datasets with distinct data for verification
+        ncd_data = np.array([100, 200, 300, 400], dtype=np.float32)
+        conforming_data = np.array([1, 2, 3, 4], dtype=np.float32)
+
+        # write both data files
+        ncd_data.tofile(ncd_path)
+        conforming_data.tofile(conforming_path)
+
+        # create metadata that references the ncd file
+        ncd_metadata = copy.deepcopy(TEST_METADATA)
+        ncd_metadata[SigMFFile.GLOBAL_KEY][SigMFFile.DATASET_KEY] = f"{base_name}.fleeb"
+        ncd_metadata[SigMFFile.GLOBAL_KEY][SigMFFile.NUM_CHANNELS_KEY] = 1
+        ncd_metadata[SigMFFile.GLOBAL_KEY][SigMFFile.DATATYPE_KEY] = "rf32_le"
+        ncd_metadata[SigMFFile.GLOBAL_KEY].pop(SigMFFile.HASH_KEY, None)
+        ncd_metadata[SigMFFile.ANNOTATION_KEY] = [{SigMFFile.LENGTH_INDEX_KEY: 4, SigMFFile.START_INDEX_KEY: 0}]
+
+        # write metadata file
+        meta = SigMFFile(metadata=ncd_metadata)
+        meta.tofile(meta_path, overwrite=True)
+
+        # verify warning is generated about conflicting datasets
+        with self.assertWarns(UserWarning):
+            loaded_meta = fromfile(meta_path)
+
+        # verify that the ncd data is loaded, not the conforming data
+        loaded_data = loaded_meta.read_samples()
+        self.assertTrue(np.array_equal(ncd_data, loaded_data), "NCD file should be prioritized over .sigmf-data")


### PR DESCRIPTION
Our team is running into an edge case where we have datasets that contain conflicting non-conforming dataset (NCD) and sigmf compliant data files. For example, we have filename.sigmf-meta, filename.cdif, and filename.sigmf-data, where the sigmf-meta has core:dataset set to filename.cdif. Currently, if we use fromfile to read in filename.sigmf-meta, it will pair the meta file with the sigmf-data file rather than the cdif. Given the SigMF spec, we would expect that if core:dataset is set, that means we have a NCD (even if a sigmf-data file with a matching filename exists), thus the file specified by core:dataset should be prioritized over the sigmf-data file.
 
From the [spec](https://sigmf.org/#ssubsec:dataset):
_The full filename of the Dataset file this Metadata file describes, used ONLY with Non-Conforming Datasets
If a Recording does not have this field, it MUST have a compliant SigMF Dataset (NOT a Non-Conforming Dataset) which MUST use the same base filename as the Metadata file and use the .sigmf-data extension_