### PR TITLE
fix annotation ordering within SigMFGenerator

### DIFF
--- a/sigmf/__init__.py
+++ b/sigmf/__init__.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 # version of this python module
-__version__ = "1.9.0"
+__version__ = "1.9.1"
 # matching version of the SigMF specification
 __specification__ = "1.2.6"
 

--- a/sigmf/siggen.py
+++ b/sigmf/siggen.py
@@ -559,6 +559,9 @@ class SigMFGenerator:
             phase_annotation = create_full_signal_annotation(f"phase offset {phase_deg:+.1f}°")
             annotations.append(phase_annotation)
 
+        # sort annotations by sample_start to satisfy sigmf ordering requirement
+        annotations.sort(key=lambda a: a[SigMFFile.START_INDEX_KEY])
+
         return annotations
 
     def _build_metadata(self, samples: np.ndarray) -> dict:

--- a/tests/test_siggen.py
+++ b/tests/test_siggen.py
@@ -316,9 +316,9 @@ class TestSigGen(unittest.TestCase):
         signal_0 = SigMFGenerator(seed=42).tone().generate()
         signal_1 = SigMFGenerator(seed=42).tone().phase_offset(phase_offset).generate()
 
-        # find where the actual signal starts by looking at annotations
-        start_idx_0 = signal_0.get_annotations()[0][SigMFFile.START_INDEX_KEY]
-        start_idx_1 = signal_1.get_annotations()[0][SigMFFile.START_INDEX_KEY]
+        # tone annotations are last after sorting (full-signal annotations start at 0)
+        start_idx_0 = signal_0.get_annotations()[-1][SigMFFile.START_INDEX_KEY]
+        start_idx_1 = signal_1.get_annotations()[-1][SigMFFile.START_INDEX_KEY]
 
         # both should start at the same sample index (same seed)
         self.assertEqual(start_idx_0, start_idx_1)


### PR DESCRIPTION
I discovered this bug while working on the `SKILL.md` examples. It's possible to generate annotations out of order raising a validation error.