### PR TITLE
include instructions for conda/mamba

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This module follows the SigMF specification [html](https://sigmf.org/)/[pdf](htt
 
 ```bash
 pip install sigmf
+# or
+conda install sigmf
+# or
+mamba install sigmf
 ```
 
 ### Read SigMF

--- a/docs/source/developers.rst
+++ b/docs/source/developers.rst
@@ -8,13 +8,13 @@ This page is for developers of the ``sigmf-python`` module.
 Install
 -------
 
-To install the latest git release, build from source:
+To install from source:
 
 .. code-block:: console
 
    $ git clone https://github.com/sigmf/sigmf-python.git
    $ cd sigmf-python
-   $ pip install .
+   $ pip install .[test]
 
 -------
 Testing

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -10,11 +10,18 @@ Here we discuss how to do all basic operations with SigMF.
 Install
 -------
 
-To install the latest PyPi release, install from pip:
+To install from PyPI using pip:
 
 .. code-block:: console
 
     $ pip install sigmf
+
+To install using conda or mamba (available via `Miniforge <https://conda-forge.org/download/>`_):
+
+.. code-block:: console
+
+    $ conda install sigmf # or
+    $ mamba install sigmf
 
 ----------------------
 Read a SigMF Recording


### PR DESCRIPTION
Now that #135 is closed I added instructions for using `mamba` to the docs.