### PR TITLE
Drop EOL Python compatability

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.9", "3.11", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PyPI Downloads Shield](https://img.shields.io/pypi/dm/sigmf)](https://pypi.org/project/SigMF/)
 
 The `sigmf` library makes it easy to interact with Signal Metadata Format
-(SigMF) recordings. This library is compatible with Python 3.7-3.14 and is distributed
+(SigMF) recordings. This library is compatible with Python 3.10-3.14 and is distributed
 freely under the terms GNU Lesser GPL v3 License.
 
 This module follows the SigMF specification [html](https://sigmf.org/)/[pdf](https://sigmf.github.io/SigMF/sigmf-spec.pdf) from the [spec repository](https://github.com/sigmf/SigMF).

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -5,6 +5,105 @@ Advanced
 Here we discuss more advanced techniques for working with **collections** and
 **archives**.
 
+-----------------------------------------------
+Load a SigMF Archive and slice without untaring
+-----------------------------------------------
+
+Since an *archive* is a tarball (uncompressed by default), you can access the
+*data* part of a SigMF archive without un-taring it. This is a compelling
+feature because **1** archives make it harder for the ``-data`` and the
+``-meta`` to get separated, and **2** some datasets are so large that it can be
+impractical (due to available disk space, or slow network speeds if the archive
+file resides on a network file share) or simply obnoxious to untar it first.
+
+::
+
+    >>> import sigmf
+    >>> signal = sigmf.fromfile('/src/LTE.sigmf')
+    >>> signal.shape
+    (15379532,)
+    >>> signal.ndim
+    1
+    >>> signal[:10]
+    array([-0.023+0.012j, -0.021-0.006j, -0.017-0.020j, -0.013-0.052j,
+            0.000-0.075j,  0.022-0.058j,  0.048-0.044j,  0.049-0.060j,
+            0.031-0.056j,  0.023-0.047j], dtype=complex64)
+
+Archives can contain fixed-point data types like ``complex-int16`` (``ci16``),
+which have no direct ``numpy`` equivalent. By default, this data is automatically
+scaled to floating-point values in the range ``[-1.0, 1.0]`` and returned as
+``numpy.complex64``:
+
+::
+
+    >>> signal.get_global_field(sigmf.DATATYPE_KEY)
+    'ci16_le'
+
+------------------------------
+Compressed SigMF Archives
+------------------------------
+
+SigMF archives can be compressed using gzip, xz, or zip.
+The file extension determines the archive format:
+
++---------------------+-------------+
+| Extension           | Format      |
++=====================+=============+
+| ``.sigmf``          | uncompressed|
++---------------------+-------------+
+| ``.sigmf.gz``       | gzip tar    |
++---------------------+-------------+
+| ``.sigmf.xz``       | xz tar      |
++---------------------+-------------+
+| ``.sigmf.zip``      | zip archive |
++---------------------+-------------+
+
+**Writing compressed archives:**
+
+::
+
+    >>> import sigmf
+    >>> signal = sigmf.sigmffile.fromfile('recording.sigmf-meta')
+
+    # extension determines format
+    >>> signal.tofile('recording.sigmf.xz')
+    >>> signal.archive('recording.sigmf.gz')
+
+    # compression parameter creates archive with correct extension
+    >>> signal.tofile('recording', compression='xz')  # → recording.sigmf.xz
+    >>> signal.archive('recording', compression='gz') # → recording.sigmf.gz
+
+**Reading compressed archives:**
+
+::
+
+    >>> signal = sigmf.fromfile('recording.sigmf.xz')
+    >>> signal[:10]
+    array([-0.023+0.012j, -0.021-0.006j, ...], dtype=complex64)
+
+**Memory behavior:**
+
+Uncompressed ``.sigmf`` archives use ``numpy.memmap`` for zero-copy access.
+Compressed archives must decompress into RAM before access.
+
+--------------------------------
+Control Fixed-Point Data Scaling
+--------------------------------
+
+You can control whether fixed-point samples are automatically scaled:
+
+.. code-block:: python
+
+    import sigmf
+
+    # Default: autoscale fixed-point data to [-1.0, 1.0] range
+    handle = sigmf.fromfile("fixed_point_data.sigmf")
+    samples = handle.read_samples()  # Returns float32/complex64
+
+    # Disable autoscaling to access raw integer values
+    handle_raw = sigmf.fromfile("fixed_point_data.sigmf", autoscale=False)
+    raw_samples = handle_raw.read_samples()  # Returns original integer types
+
 ------------------------------
 Iterate over SigMF Annotations
 ------------------------------
@@ -150,84 +249,3 @@ The SigMF Collection and its associated Recordings can now be loaded like this:
     collection = sigmf.fromfile("example_zeros")
     ci16_sigmffile = collection.get_SigMFFile(stream_name="example_ci16")
     cf32_sigmffile = collection.get_SigMFFile(stream_name="example_cf32")
-
------------------------------------------------
-Load a SigMF Archive and slice without untaring
------------------------------------------------
-
-Since an *archive* is a tarball (uncompressed by default), you can access the
-*data* part of a SigMF archive without un-taring it. This is a compelling
-feature because **1** archives make it harder for the ``-data`` and the
-``-meta`` to get separated, and **2** some datasets are so large that it can be
-impractical (due to available disk space, or slow network speeds if the archive
-file resides on a network file share) or simply obnoxious to untar it first.
-
-::
-
-    >>> import sigmf
-    >>> signal = sigmf.fromarchive('/src/LTE.sigmf')
-    >>> signal.shape
-    (15379532,)
-    >>> signal.ndim
-    1
-    >>> signal[:10]
-    array([-0.023+0.012j, -0.021-0.006j, -0.017-0.020j, -0.013-0.052j,
-            0.000-0.075j,  0.022-0.058j,  0.048-0.044j,  0.049-0.060j,
-            0.031-0.056j,  0.023-0.047j], dtype=complex64)
-
-Archives can contain fixed-point data types like ``complex-int16`` (``ci16``),
-which have no direct ``numpy`` equivalent. By default, this data is automatically
-scaled to floating-point values in the range ``[-1.0, 1.0]`` and returned as
-``numpy.complex64``:
-
-::
-
-    >>> signal.get_global_field(sigmf.DATATYPE_KEY)
-    'ci16_le'
-
-------------------------------
-Compressed SigMF Archives
-------------------------------
-
-SigMF archives can be compressed using gzip, xz, or zip.
-The file extension determines the archive format:
-
-+---------------------+-------------+
-| Extension           | Format      |
-+=====================+=============+
-| ``.sigmf``          | uncompressed|
-+---------------------+-------------+
-| ``.sigmf.gz``       | gzip tar    |
-+---------------------+-------------+
-| ``.sigmf.xz``       | xz tar      |
-+---------------------+-------------+
-| ``.sigmf.zip``      | zip archive |
-+---------------------+-------------+
-
-**Writing compressed archives:**
-
-::
-
-    >>> import sigmf
-    >>> signal = sigmf.sigmffile.fromfile('recording.sigmf-meta')
-
-    # extension determines format
-    >>> signal.tofile('recording.sigmf.xz')
-    >>> signal.archive('recording.sigmf.gz')
-
-    # compression parameter creates archive with correct extension
-    >>> signal.tofile('recording', compression='xz')  # → recording.sigmf.xz
-    >>> signal.archive('recording', compression='gz') # → recording.sigmf.gz
-
-**Reading compressed archives:**
-
-::
-
-    >>> signal = sigmf.fromfile('recording.sigmf.xz')
-    >>> signal[:10]
-    array([-0.023+0.012j, -0.021-0.006j, ...], dtype=complex64)
-
-**Memory behavior:**
-
-Uncompressed ``.sigmf`` archives use ``numpy.memmap`` for zero-copy access.
-Compressed archives must decompress into RAM before access.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -10,6 +10,32 @@ Frequently Asked Questions
     Formulate them as a question and an answer.
     Consider that the answer is best as a reference to another place in the documentation.
 
+----------------------------------------
+Can I use my own custom metadata fields?
+----------------------------------------
+
+*Yes*, you can add arbitrary fields to the ``global``, ``captures``, and
+``annotations`` objects. However, we recommend defining custom fields in a
+SigMF extension and listing that extension in ``core:extensions`` so that other
+tools can understand your metadata:
+
+.. code-block:: json
+
+    "global": {
+        "core:extensions": [
+            {
+                "name": "my-extension",
+                "version": "0.0.1",
+                "optional": true
+            }
+        ],
+        "my-extension:my_field": "some value"
+    }
+
+If you think your extension will be useful to others, consider publishing it or
+submitting it to the `SigMF Community Extensions repository
+<https://github.com/sigmf/community-extensions>`_.
+
 ---------------------------
 Is this a GNU Radio effort?
 ---------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,7 @@ It offers a *simple* and *intuitive* API for Python developers.
 This documentation is for version |toolversion| of the library, which is
 compatible with version |specversion| of the SigMF specification.
 
-To get started, see `quickstart`.
+To get started, see :doc:`quickstart`.
 
 -----
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -164,24 +164,3 @@ method-based approach.
    Only core **global** fields support attribute access. Capture and annotation
    fields must still be accessed using the traditional ``get_captures()`` and
    ``get_annotations()`` methods.
-
---------------------------------
-Control Fixed-Point Data Scaling
---------------------------------
-
-For fixed-point datasets, you can control whether samples are automatically scaled to floating-point values:
-
-.. code-block:: python
-
-    import sigmf
-
-    # Default behavior: autoscale fixed-point data to [-1.0, 1.0] range
-    handle = sigmf.fromfile("fixed_point_data.sigmf")
-    samples = handle.read_samples()  # Returns float32/complex64
-
-    # Disable autoscaling to access raw integer values
-    handle_raw = sigmf.fromfile("fixed_point_data.sigmf", autoscale=False)
-    raw_samples = handle_raw.read_samples()  # Returns original integer types
-
-    # Both slicing and read_samples() respect the autoscale setting
-    assert handle[0:10].dtype == handle.read_samples(count=10).dtype

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,6 @@ classifiers = [
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -20,7 +17,7 @@ classifiers = [
     "Topic :: Communications :: Ham Radio",
 ]
 dynamic = ["version", "readme"]
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dependencies = [
     "numpy",        # for vector math
     "jsonschema",   # for spec validation
@@ -106,7 +103,7 @@ line-length = 120
 legacy_tox_ini = '''
     [tox]
     skip_missing_interpreters = True
-    envlist = py{37,38,39,310,311,312,313,314}
+    envlist = py{310,311,312,313,314}
 
     [testenv]
     usedevelop = True

--- a/sigmf/__init__.py
+++ b/sigmf/__init__.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 # version of this python module
-__version__ = "1.11.2"
+__version__ = "1.12.0"
 # matching version of the SigMF specification
 __specification__ = "1.2.6"
 

--- a/sigmf/convert/__init__.py
+++ b/sigmf/convert/__init__.py
@@ -80,12 +80,12 @@ def detect_converter(file_path: Path):
             return "signalhound"
         else:
             raise SigMFConversionError(
-                f"Unsupported XML file format. Root element: {expanded_magic_bytes}. "
+                f"Unsupported XML file format. Root element: {expanded_magic_bytes.decode('utf-8', errors='replace')}. "
                 f"Expected SignalHoundIQFile for Signal Hound Spike files."
             )
 
     else:
         raise SigMFConversionError(
-            f"Unsupported file format. Magic bytes: {magic_bytes}. "
+            f"Unsupported file format. Magic bytes: {magic_bytes.decode('utf-8', errors='replace')}. "
             f"Supported formats for conversion are WAV, BLUE/Platinum, and Signal Hound Spike."
         )

--- a/sigmf/convert/blue.py
+++ b/sigmf/convert/blue.py
@@ -20,7 +20,6 @@ import tempfile
 from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
-from typing import Optional, Tuple
 
 import numpy as np
 from packaging.version import InvalidVersion, Version
@@ -474,7 +473,7 @@ def _build_common_metadata(
     is_ncd: bool = False,
     blue_file_name: str = None,
     trailing_bytes: int = 0,
-) -> Tuple[dict, dict]:
+) -> tuple[dict, dict]:
     """
     Build common global_info and capture_info metadata for both standard and NCD SigMF files.
 
@@ -791,7 +790,7 @@ def construct_sigmf_ncd(
 
 def blue_to_sigmf(
     blue_path: str,
-    out_path: Optional[str] = None,
+    out_path: str | None = None,
     create_archive: bool = False,
     create_ncd: bool = False,
     overwrite: bool = False,

--- a/sigmf/convert/blue.py
+++ b/sigmf/convert/blue.py
@@ -64,20 +64,20 @@ FIXED_LAYOUT = [
 
 BLOCK_SIZE_BYTES = 512
 
-TYPE_MAP = {
+TYPE_MAP: dict[str, np.dtype] = {
     # BLUE format code to numpy dtype
     # note: new non 1-1 mapping supported needs new handling in data_loopback
     # "P" : packed bits,
     "A": np.dtype("S1"),  # ASCII for unpacking text fields
     # "N" : 4-bit integer,
-    "B": np.int8,
-    "U": np.uint16,
-    "I": np.int16,
-    "V": np.uint32,
-    "L": np.int32,
-    "F": np.float32,
-    "X": np.int64,
-    "D": np.float64,
+    "B": np.dtype(np.int8),
+    "U": np.dtype(np.uint16),
+    "I": np.dtype(np.int16),
+    "V": np.dtype(np.uint32),
+    "L": np.dtype(np.int32),
+    "F": np.dtype(np.float32),
+    "X": np.dtype(np.int64),
+    "D": np.dtype(np.float64),
     # "O": excess-128,
 }
 
@@ -97,15 +97,14 @@ def blue_to_sigmf_type_str(h_fixed: dict) -> str:
         SigMF datatype string (e.g., 'ci16_le', 'rf32_be').
     """
     # extract format code and endianness from header
-    format_code = h_fixed.get("format")
-    endianness = h_fixed.get("data_rep")
+    format_code: str = h_fixed["format"]
+    endianness: str = h_fixed["data_rep"]
 
     # parse format code components
     is_complex = format_code[0] == "C"
-    numpy_dtype = TYPE_MAP[format_code[1]]
+    dtype_obj = TYPE_MAP[format_code[1]]
 
     # compute everything from numpy dtype
-    dtype_obj = np.dtype(numpy_dtype)
     bits = dtype_obj.itemsize * 8  # bytes to bits
 
     # infer sigmf type from numpy kind
@@ -155,7 +154,7 @@ def detect_endian(data: bytes) -> str:
     raise SigMFConversionError(f"Unsupported endianness: {endianness}")
 
 
-def read_hcb(file_path: Path) -> (dict, dict):
+def read_hcb(file_path: Path) -> tuple[dict, dict]:
     """
     Read Header Control Block (HCB) from BLUE file.
 
@@ -269,7 +268,7 @@ def read_extended_header(file_path: Path, h_fixed: dict) -> list:
     SigMFConversionError
         If the extended header cannot be parsed.
     """
-    entries = []
+    entries: list[dict] = []
     if h_fixed["ext_size"] <= 0:
         return entries
     endian = "<" if h_fixed.get("head_rep") == "EEEI" else ">"
@@ -285,7 +284,7 @@ def read_extended_header(file_path: Path, h_fixed: dict) -> list:
             # get dtype and compute bytes per element
             if type_char in TYPE_MAP:
                 dtype = TYPE_MAP[type_char]
-                bytes_per_element = np.dtype(dtype).itemsize
+                bytes_per_element = dtype.itemsize
             else:
                 # fallback for unknown types
                 dtype = np.dtype("S1")
@@ -300,9 +299,9 @@ def read_extended_header(file_path: Path, h_fixed: dict) -> list:
                     raise SigMFConversionError("Unexpected end of extended header")
                 value = raw.rstrip(b"\x00").decode("ascii", errors="replace")
             else:
-                value = np.frombuffer(handle.read(val_len), dtype=dtype, count=val_count)
-                if value.size == 1:
-                    val_item = value[0]
+                ray = np.frombuffer(handle.read(val_len), dtype=dtype, count=val_count)
+                if ray.size == 1:
+                    val_item = ray[0]
                     # handle bytes first (numpy.bytes_ is also np.generic)
                     if isinstance(val_item, bytes):
                         # handle bytes from S1 dtype - convert to base64 for JSON
@@ -313,7 +312,7 @@ def read_extended_header(file_path: Path, h_fixed: dict) -> list:
                     else:
                         value = val_item
                 else:
-                    value = value.tolist()
+                    value = ray.tolist()
 
             tag = handle.read(ltag).decode("ascii", errors="replace") if ltag > 0 else ""
 
@@ -434,13 +433,13 @@ def _crc32_broken(data: bytes) -> str:
     return f"{(~crc) & 0xFFFFFFFF:08x}"
 
 
-def _get_blue_boundaries(blue_path: Path, h_fixed: dict) -> (int, int):
+def _get_blue_boundaries(blue_path: Path, h_fixed: dict) -> tuple[int, int, int]:
     """
     Extract data boundaries from fixed header.
     """
     file_bytes = blue_path.stat().st_size
-    header_bytes = int(h_fixed.get("data_start"))
-    data_bytes = int(h_fixed.get("data_size"))
+    header_bytes = int(h_fixed["data_start"])
+    data_bytes = int(h_fixed["data_size"])
     trailing_bytes = file_bytes - (header_bytes + data_bytes)
     return header_bytes, data_bytes, trailing_bytes
 
@@ -451,7 +450,7 @@ def _description(h_fixed: dict) -> str:
     """
     try:
         spec_str = "Unknown"
-        version = Version(h_fixed.get("keywords").get("VER", "0.0"))
+        version = Version(h_fixed["keywords"].get("VER", "0.0"))
         if version.major == 1:
             spec_str = f"BLUE {version}"
         elif version.major == 2:
@@ -471,7 +470,7 @@ def _build_common_metadata(
     h_adjunct: dict,
     h_extended: list,
     is_ncd: bool = False,
-    blue_file_name: str = None,
+    blue_file_name: str | None = None,
     trailing_bytes: int = 0,
 ) -> tuple[dict, dict]:
     """
@@ -542,7 +541,7 @@ def _build_common_metadata(
     # merge extended header fields, handling duplicate keys
     if h_extended:
         extended = {}
-        tag_counts = {}
+        tag_counts: dict[str, int] = {}
         for entry in h_extended:
             tag = entry.get("tag")
             value = entry.get("value")
@@ -561,7 +560,7 @@ def _build_common_metadata(
     # calculate blue start time
     blue_start_time = float(h_fixed.get("timecode", 0))
     blue_start_time += h_adjunct.get("xstart", 0)
-    blue_start_time += float(h_fixed.get("keywords").get("TC_PREC", 0))
+    blue_start_time += float(h_fixed["keywords"].get("TC_PREC", 0))
 
     capture_info = {}
 
@@ -789,8 +788,8 @@ def construct_sigmf_ncd(
 
 
 def blue_to_sigmf(
-    blue_path: str,
-    out_path: str | None = None,
+    blue_path: str | Path,
+    out_path: str | Path | None = None,
     create_archive: bool = False,
     create_ncd: bool = False,
     overwrite: bool = False,
@@ -800,9 +799,9 @@ def blue_to_sigmf(
 
     Parameters
     ----------
-    blue_path : str
+    blue_path : str or Path
         Path to the Blue file.
-    out_path : str, optional
+    out_path : str or Path, optional
         Path to the output SigMF metadata file.
     create_archive : bool, optional
         When True, package output as a .sigmf archive.

--- a/sigmf/convert/signalhound.py
+++ b/sigmf/convert/signalhound.py
@@ -334,8 +334,8 @@ def _add_annotations(meta: SigMFFile, annotations: list) -> None:
 
 
 def signalhound_to_sigmf(
-    signalhound_path: Path,
-    out_path: Path | None = None,
+    signalhound_path: str | Path,
+    out_path: str | Path | None = None,
     create_archive: bool = False,
     create_ncd: bool = False,
     overwrite: bool = False,
@@ -345,9 +345,9 @@ def signalhound_to_sigmf(
 
     Parameters
     ----------
-    signalhound_path : Path
+    signalhound_path : str or Path
         Path to the signalhound file.
-    out_path : Path, optional
+    out_path : str or Path, optional
         Path to the output SigMF metadata file.
     create_archive : bool, optional
         When True, package output as a .sigmf archive.

--- a/sigmf/convert/signalhound.py
+++ b/sigmf/convert/signalhound.py
@@ -12,7 +12,6 @@ import logging
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import List, Optional, Tuple
 from xml.etree.ElementTree import Element
 
 import defusedxml.ElementTree as ET
@@ -26,13 +25,13 @@ from ..utils import SIGMF_DATETIME_ISO8601_FMT
 log = logging.getLogger()
 
 
-def _text_of(root: Element, tag: str) -> Optional[str]:
+def _text_of(root: Element, tag: str) -> str | None:
     """Extract and strip text from XML element."""
     elem = root.find(tag)
     return elem.text.strip() if (elem is not None and elem.text is not None) else None
 
 
-def _parse_preview_trace(text: Optional[str]) -> List[float]:
+def _parse_preview_trace(text: str | None) -> list[float]:
     """
     Preview trace is a max-hold trace of the signal power across the capture, represented as a comma-separated string of values.
 
@@ -112,7 +111,7 @@ def validate_spike(xml_path: Path) -> None:
         raise SigMFConversionError(f"IQ file size {filesize} not divisible by {frame_bytes}; partial sample present")
 
 
-def _build_metadata(xml_path: Path) -> Tuple[dict, dict, list, int]:
+def _build_metadata(xml_path: Path) -> tuple[dict, dict, list, int]:
     """
     Build SigMF metadata components from the Spike XML file.
 
@@ -336,7 +335,7 @@ def _add_annotations(meta: SigMFFile, annotations: list) -> None:
 
 def signalhound_to_sigmf(
     signalhound_path: Path,
-    out_path: Optional[Path] = None,
+    out_path: Path | None = None,
     create_archive: bool = False,
     create_ncd: bool = False,
     overwrite: bool = False,

--- a/sigmf/convert/wav.py
+++ b/sigmf/convert/wav.py
@@ -72,8 +72,8 @@ def _get_wav_boundaries(wav_path: Path) -> tuple[int, int]:
 
 
 def wav_to_sigmf(
-    wav_path: str,
-    out_path: str | None = None,
+    wav_path: str | Path,
+    out_path: str | Path | None = None,
     create_archive: bool = False,
     create_ncd: bool = False,
     overwrite: bool = False,
@@ -83,9 +83,9 @@ def wav_to_sigmf(
 
     Parameters
     ----------
-    wav_path : str
+    wav_path : str or Path
         Path to the WAV file.
-    out_path : str, optional
+    out_path : str or Path, optional
         Path to the output SigMF metadata file.
     create_archive : bool, optional
         When True, package output as a .sigmf archive.
@@ -182,7 +182,7 @@ def wav_to_sigmf(
     if out_path is None:
         base_path = wav_path.with_suffix(".sigmf")
     else:
-        base_path = Path(out_path)
+        base_path = out_path
 
     filenames = get_sigmf_filenames(base_path)
 

--- a/sigmf/convert/wav.py
+++ b/sigmf/convert/wav.py
@@ -12,12 +12,10 @@ import tempfile
 import wave
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional, Tuple
 
 import numpy as np
 
-from .. import SigMFFile
-from .. import fromfile, keys
+from .. import SigMFFile, fromfile, keys
 from ..error import SigMFFileExistsError
 from ..sigmffile import get_sigmf_filenames
 from ..utils import SIGMF_DATETIME_ISO8601_FMT, get_data_type_str
@@ -25,7 +23,7 @@ from ..utils import SIGMF_DATETIME_ISO8601_FMT, get_data_type_str
 log = logging.getLogger()
 
 
-def _get_wav_boundaries(wav_path: Path) -> Tuple[int, int]:
+def _get_wav_boundaries(wav_path: Path) -> tuple[int, int]:
     """
     Calculate header_bytes and trailing_bytes for WAV NCD.
 
@@ -75,7 +73,7 @@ def _get_wav_boundaries(wav_path: Path) -> Tuple[int, int]:
 
 def wav_to_sigmf(
     wav_path: str,
-    out_path: Optional[str] = None,
+    out_path: str | None = None,
     create_archive: bool = False,
     create_ncd: bool = False,
     overwrite: bool = False,

--- a/sigmf/siggen.py
+++ b/sigmf/siggen.py
@@ -47,20 +47,20 @@ class SigMFGenerator:
         self._seed = seed
 
         # signal components (list of dicts)
-        self._signal_components = []
+        self._signal_components: list[dict] = []
 
         # signal configuration
-        self._sample_rate_hz = None
-        self._duration_s = None
-        self._amplitude = 1.0
-        self._snr_db = None
-        self._frequency_offset_hz = 0.0
-        self._phase_offset_rad = 0.0
+        self._sample_rate_hz: float | None = None
+        self._duration_s: float | None = None
+        self._amplitude: float = 1.0
+        self._snr_db: float | None = None
+        self._frequency_offset_hz: float = 0.0
+        self._phase_offset_rad: float = 0.0
 
         # metadata
-        self._author = None
-        self._description = None
-        self._comment = None
+        self._author: str | None = None
+        self._description: str | None = None
+        self._comment: str | None = None
 
     def tone(self, frequency_hz: float | None = None, amplitude: float | None = None):
         """
@@ -78,7 +78,7 @@ class SigMFGenerator:
         SigMFGenerator
             Self for method chaining.
         """
-        component = {"type": "tone"}
+        component: dict = {"type": "tone"}
         if frequency_hz is not None:
             component["frequency_hz"] = float(frequency_hz)
         if amplitude is not None:
@@ -109,7 +109,7 @@ class SigMFGenerator:
         SigMFGenerator
             Self for method chaining.
         """
-        component = {"type": "sweep"}
+        component: dict = {"type": "sweep"}
         if start_frequency_hz is not None:
             component["start_frequency_hz"] = float(start_frequency_hz)
         if end_frequency_hz is not None:
@@ -310,7 +310,7 @@ class SigMFGenerator:
     def _fill_random_parameters(self) -> None:
         """Fill unspecified parameters with random values."""
         # sample rates to choose from
-        common_sample_rates = []
+        common_sample_rates: list[float] = []
         # typical audio rates
         common_sample_rates += [8000, 22050, 44100, 48000, 96000, 192000]
         # typical SDR rates

--- a/sigmf/siggen.py
+++ b/sigmf/siggen.py
@@ -7,7 +7,6 @@
 """Simple signal generator utilities for SigMF."""
 
 import io
-from typing import Optional
 
 import numpy as np
 
@@ -42,7 +41,7 @@ class SigMFGenerator:
     >>> signal = SigMFGenerator().sample_rate(100e3).tone(440).sweep(1000, 5000).duration(0.5).generate()
     """
 
-    def __init__(self, seed: Optional[int] = None):
+    def __init__(self, seed: int | None = None):
         # random state for reproducible generation across arch / platforms
         self._rng = np.random.RandomState(seed)
         self._seed = seed
@@ -63,7 +62,7 @@ class SigMFGenerator:
         self._description = None
         self._comment = None
 
-    def tone(self, frequency_hz: Optional[float] = None, amplitude: Optional[float] = None):
+    def tone(self, frequency_hz: float | None = None, amplitude: float | None = None):
         """
         Add a sinusoidal tone to the signal.
 
@@ -89,9 +88,9 @@ class SigMFGenerator:
 
     def sweep(
         self,
-        start_frequency_hz: Optional[float] = None,
-        end_frequency_hz: Optional[float] = None,
-        amplitude: Optional[float] = None,
+        start_frequency_hz: float | None = None,
+        end_frequency_hz: float | None = None,
+        amplitude: float | None = None,
     ):
         """
         Add a linear frequency sweep to the signal.

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -85,7 +85,7 @@ class _SigMFDeprecatingMeta(type):
 
 
 class SigMFMetafile(metaclass=_SigMFDeprecatingMeta):
-    VALID_KEYS = {}
+    VALID_KEYS: dict[str, list[str]] = {}
 
     def __init__(self):
         self.version = None

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -1043,7 +1043,7 @@ class SigMFCollection(SigMFMetafile):
     VALID_KEYS = {COLLECTION_KEY: VALID_COLLECTION_KEYS}
 
     def __init__(
-        self, metafiles: list = None, metadata: dict = None, base_path=None, skip_checksums: bool = False
+        self, metafiles: list | None = None, metadata: dict | None = None, base_path=None, skip_checksums: bool = False
     ) -> None:
         """
         Create a SigMF Collection object.
@@ -1118,7 +1118,7 @@ class SigMFCollection(SigMFMetafile):
                         f"Calculated file hash for {metafile_path} does not match collection metadata."
                     )
 
-    def set_streams(self, metafiles) -> None:
+    def set_streams(self, metafiles: list) -> None:
         """
         Configures the collection `core:streams` field from the specified list of metafiles.
         """
@@ -1502,18 +1502,22 @@ def fromfile(filename, skip_checksum=False, autoscale=True):
     raise SigMFFileError(f"Cannot read {filename} as SigMF or supported non-SigMF format.")
 
 
-def get_sigmf_filenames(filename):
+def get_sigmf_filenames(filename: str | Path) -> dict[str, Path]:
     """
-    Safely returns a set of SigMF file paths given an input filename.
+    Safely returns a set of SigMF file paths given a file path.
 
     Parameters
     ----------
-    filename : str | bytes | PathLike
+    filename : str | Path
         The SigMF filename with any extension.
 
     Returns
     -------
-    dict with filename keys.
+    dict[str, Path]
+        Dictionary with keys 'base_fn', 'data_fn', 'meta_fn', 'archive_fn',
+        'collection_fn' and Path values. The directory component of the input
+        is preserved; only the extension is normalized. Paths are returned in
+        the same form (absolute or relative) as the input.
     """
     stem_path = Path(filename)
     # If the path has a sigmf suffix, remove it. Otherwise do not remove the

--- a/sigmf/validate.py
+++ b/sigmf/validate.py
@@ -18,9 +18,6 @@ import warnings
 # cost for small SigMF files. Swap to ProcessPool if files are large.
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-# required for Python 3.7
-from typing import Optional, Tuple
-
 import jsonschema
 
 from . import __version__ as toolversion
@@ -131,7 +128,7 @@ def _validate_single_file(filename, skip_checksum: bool, logger: logging.Logger)
         return 0
 
 
-def main(arg_tuple: Optional[Tuple[str, ...]] = None) -> None:
+def main(arg_tuple: tuple[str, ...] | None = None) -> None:
     """entry-point for command-line validator"""
     parser = argparse.ArgumentParser(
         description="Validate SigMF Archive or file pair against JSON schema.", prog="sigmf_validate"


### PR DESCRIPTION
[As noted on this page](https://www.python.org/downloads/) python versions prior to 3.10 are already end-of-life.

By dropping support for these versions we can use more modern typing and make the code more robust. We are already actually pinned to 3.10 because the minimum version for jsonschema right now is already 3.10. You will discover this if you try to make a new 3.7 environment and try to install `sigmf`. Conda-forge recognized this for us and already had the minimum version for sigmf set to 3.10.

This will increment version to `v1.12.0`.